### PR TITLE
Point install URL at armoriq.ai instead of raw.githubusercontent.com

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -19,7 +19,7 @@ echo "# Demo project" > README.md
 
 **On screen:**
 ```
-$ curl -fsSL https://raw.githubusercontent.com/armoriq/armorClaude/main/install_armorclaude.sh | bash
+$ curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 ```
 
 **Voiceover:**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,7 +5,7 @@ Five-minute path from `curl` to your first blocked tool call.
 ## 1. Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/armoriq/armorClaude/main/install_armorclaude.sh | bash
+curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 ```
 
 The installer adds the `armoriq` Claude Code marketplace and installs the `armorclaude` plugin. No API key required for the local-only demo.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tool Result ──► PostToolUse hook ──► Audit log sent to IAP
 ### One-line install (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/armoriq/armorClaude/main/install_armorclaude.sh | bash
+curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 ```
 
 This adds the `armoriq` Claude Code marketplace and installs the `armorclaude` plugin. Dependencies are installed automatically on first hook fire.

--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 # ArmorClaude installer for Claude Code
 #
 # Usage:
-#   curl -fsSL https://armoriq.ai/install-armorclaude.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/armoriq/armorClaude/main/install_armorclaude.sh | bash
+#   curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 #
 # Non-interactive overrides:
 #   ARMORIQ_API_KEY=ak_live_...           skip the API-key prompt, use this key


### PR DESCRIPTION
Repo is private; raw.githubusercontent.com URLs return 404 to anyone without org access. The installer is now served from the landing site's public/ folder (PR armoriq/armorIQ-landing#15) so the curl command works for any user.