### PR TITLE
Simplify installer: drop API-key prompts, local-only by default

### DIFF
--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -7,9 +7,6 @@ set -euo pipefail
 #   curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 #
 # Non-interactive overrides:
-#   ARMORIQ_API_KEY=ak_live_...           skip the API-key prompt, use this key
-#   ARMORCLAUDE_SKIP_KEY=1                skip the API-key step entirely
-#   ARMORCLAUDE_NO_PROMPT=1               assume defaults for every prompt
 #   ARMORCLAUDE_MARKETPLACE_REPO=<path>   override marketplace source (testing)
 
 R=$'\033[1;31m'
@@ -24,7 +21,6 @@ N=$'\033[0m'
 MARKETPLACE_REPO="${ARMORCLAUDE_MARKETPLACE_REPO:-armoriq/armorClaude}"
 PLUGIN_REF="armorclaude@armoriq"
 DASHBOARD_URL="https://dev.armoriq.ai"
-API_KEY_INPUT="${ARMORIQ_API_KEY:-}"
 
 # Recover if the caller launched the installer from a directory that was deleted.
 if ! pwd >/dev/null 2>&1; then
@@ -57,66 +53,6 @@ ${C}${B}    ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝ ╚�
 EOF
 }
 
-is_promptable() {
-  [[ "${ARMORCLAUDE_NO_PROMPT:-0}" == "1" ]] && return 1
-  # /dev/tty must exist AND actually be openable from this process
-  # (a piped/no-controlling-tty install will fail the second check).
-  [[ -e /dev/tty ]] || return 1
-  (: < /dev/tty) 2>/dev/null || return 1
-  return 0
-}
-
-prompt_yes_no() {
-  # $1 = question, $2 = default (Y or N)
-  local question="$1"
-  local default="${2:-Y}"
-  local hint="(Y/n)"
-  [[ "$default" == "N" ]] && hint="(y/N)"
-  if ! is_promptable; then
-    [[ "$default" == "Y" ]]
-    return $?
-  fi
-  local answer
-  printf "${B}?${N} %s ${D}%s${N} " "$question" "$hint" >&2
-  read -r answer < /dev/tty || answer=""
-  if [[ -z "$answer" ]]; then
-    [[ "$default" == "Y" ]]
-    return $?
-  fi
-  [[ "$answer" =~ ^[Yy] ]]
-}
-
-prompt_secret() {
-  # $1 = prompt
-  local prompt_text="$1"
-  if ! is_promptable; then
-    echo ""
-    return 0
-  fi
-  printf "${B}?${N} %s\n  ${D}(input hidden, paste then press Enter)${N}\n  > " "$prompt_text" >&2
-  local result
-  # Use stty to disable echo for the masked input
-  if stty -echo < /dev/tty 2>/dev/null; then
-    read -r result < /dev/tty || result=""
-    stty echo < /dev/tty 2>/dev/null || true
-    echo "" >&2
-  else
-    read -r result < /dev/tty || result=""
-  fi
-  echo "$result"
-}
-
-open_url() {
-  local url="$1"
-  if command -v open >/dev/null 2>&1; then
-    open "$url" >/dev/null 2>&1 &
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$url" >/dev/null 2>&1 &
-  else
-    return 1
-  fi
-}
-
 # ---------------------------------------------------------------------------
 # Prereq checks
 # ---------------------------------------------------------------------------
@@ -140,113 +76,6 @@ check_node_version() {
   if [[ -z "${major}" || "${major}" -lt 20 ]]; then
     err "Node.js >= 20 required (found ${raw:-none})"
     exit 1
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# API key flow
-# ---------------------------------------------------------------------------
-
-valid_api_key() {
-  [[ "$1" =~ ^ak_(live|test)_[a-zA-Z0-9]{32,}$ ]]
-}
-
-api_key_step() {
-  if [[ -n "$API_KEY_INPUT" ]]; then
-    if valid_api_key "$API_KEY_INPUT"; then
-      ok "using API key from environment"
-      return 0
-    else
-      warn "ARMORIQ_API_KEY in env doesn't look valid (expected ak_live_... or ak_test_...) — ignoring"
-      API_KEY_INPUT=""
-    fi
-  fi
-
-  if [[ "${ARMORCLAUDE_SKIP_KEY:-0}" == "1" ]]; then
-    info "skipping API key (ARMORCLAUDE_SKIP_KEY=1) — local-only mode active"
-    return 0
-  fi
-
-  section "ArmorIQ API key (optional)"
-  cat <<EOF
-
-  ArmorClaude works in two modes:
-
-    ${G}${B}Local-only${N}  ${D}(no key)${N}      intent enforcement, policy rules, drift detection
-    ${C}${B}Backend-connected${N}  ${D}(key)${N}  + signed JWT tokens, audit logs, CSRG proofs
-
-EOF
-
-  if ! prompt_yes_no "Do you have an ArmorIQ API key?" "Y"; then
-    echo
-    info "No problem. Get one any time at:"
-    printf "    ${C}${B}%s${N}\n" "$DASHBOARD_URL"
-    if prompt_yes_no "  Open the dashboard now?" "Y"; then
-      if open_url "$DASHBOARD_URL"; then
-        ok "opened $DASHBOARD_URL"
-      else
-        warn "couldn't auto-open browser — visit $DASHBOARD_URL manually"
-      fi
-      echo
-      if prompt_yes_no "  Once you have a key, ready to paste it now?" "Y"; then
-        :  # fall through to paste step
-      else
-        info "skipped — local-only mode active. You can set ARMORIQ_API_KEY later."
-        return 0
-      fi
-    else
-      info "skipped — local-only mode active. You can set ARMORIQ_API_KEY later."
-      return 0
-    fi
-  fi
-
-  echo
-  for attempt in 1 2 3; do
-    API_KEY_INPUT="$(prompt_secret "Paste your ArmorIQ API key (ak_live_... or ak_test_...)")"
-    if [[ -z "$API_KEY_INPUT" ]]; then
-      warn "no key entered — skipping (local-only mode active)"
-      return 0
-    fi
-    if valid_api_key "$API_KEY_INPUT"; then
-      ok "API key looks valid"
-      return 0
-    fi
-    warn "that doesn't look like an ArmorIQ key (expected ak_live_... or ak_test_...). Try again ($attempt/3)."
-  done
-  warn "giving up on API key after 3 attempts — local-only mode active"
-  API_KEY_INPUT=""
-}
-
-persist_api_key() {
-  [[ -z "$API_KEY_INPUT" ]] && return 0
-
-  local export_line="export ARMORIQ_API_KEY=\"$API_KEY_INPUT\"  # ArmorClaude — added by install_armorclaude.sh"
-  local persisted_to=()
-  local rc
-
-  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
-    [[ -f "$rc" ]] || continue
-    # Strip any prior ArmorClaude-managed line first (idempotent re-run)
-    if grep -q "ArmorClaude — added by install_armorclaude.sh" "$rc" 2>/dev/null; then
-      # In-place strip without sed -i portability headaches
-      local tmp
-      tmp="$(mktemp)"
-      grep -v "ArmorClaude — added by install_armorclaude.sh" "$rc" > "$tmp" || true
-      cat "$tmp" > "$rc"
-      rm -f "$tmp"
-    fi
-    printf "\n%s\n" "$export_line" >> "$rc"
-    persisted_to+=("$rc")
-  done
-
-  # Also export it for the rest of THIS process so the verify step works.
-  export ARMORIQ_API_KEY="$API_KEY_INPUT"
-
-  if [[ ${#persisted_to[@]} -gt 0 ]]; then
-    ok "saved ARMORIQ_API_KEY to: ${persisted_to[*]}"
-    info "open a new shell or run: ${B}source ${persisted_to[0]}${N}"
-  else
-    warn "no shell rc file found (~/.zshrc, ~/.bashrc, ~/.bash_profile) — set ARMORIQ_API_KEY manually"
   fi
 }
 
@@ -286,32 +115,38 @@ verify_install() {
 
 finale() {
   echo
-  printf "${G}${B}ArmorClaude is installed.${N}\n\n"
+  printf "${G}${B}ArmorClaude is installed.${N}\n"
 
   section "Quick start"
   cat <<EOF
 
-  ${C}1.${N} Start a Claude Code session in any project:
-       ${D}claude${N}
+  Start a Claude Code session in any project:
 
-  ${C}2.${N} Try a prompt — ArmorClaude will tell Claude to register an intent
-     plan first. Tools not in the plan get blocked (intent drift).
+    ${G}${B}claude${N}
 
-  ${C}3.${N} Add policy rules from any prompt, e.g.:
-       ${D}> Policy new: deny WebFetch${N}
+  Try a prompt — ArmorClaude will tell Claude to register an intent
+  plan first. Tools not in the plan get blocked (intent drift).
+
+  Add policy rules from any prompt:
+
+    ${D}> Policy new: deny WebFetch${N}
 
 EOF
 
-  if [[ -z "$API_KEY_INPUT" ]]; then
-    section "Optional: connect to ArmorIQ"
-    printf "  Get an API key at ${C}${B}%s${N}\n" "$DASHBOARD_URL"
-    printf "  Then set it once: ${D}export ARMORIQ_API_KEY=ak_live_...${N}\n\n"
-    printf "  This unlocks: signed JWT tokens, audit logs to IAP, CSRG proofs.\n\n"
-  else
-    section "Backend connected"
-    printf "  Audit logs and signed tokens are flowing to ${C}staging-api.armoriq.ai${N}\n"
-    printf "  View your runs at ${C}${B}%s${N}\n\n" "$DASHBOARD_URL"
-  fi
+  section "Optional: connect to ArmorIQ"
+  cat <<EOF
+
+  Unlocks: signed JWT intent tokens, audit logs to IAP, CSRG proofs,
+  remote step verification, dashboard visibility.
+
+  ${C}1.${N} Get an API key at ${C}${B}${DASHBOARD_URL}${N}
+  ${C}2.${N} Add this line to your shell rc (~/.zshrc or ~/.bashrc):
+
+       ${D}export ARMORIQ_API_KEY=ak_live_...${N}
+
+  ${C}3.${N} Open a new terminal (or ${B}source${N} the rc file) and run ${B}claude${N}.
+
+EOF
 
   section "Manage anytime"
   cat <<EOF
@@ -321,9 +156,9 @@ EOF
   ${D}claude plugin enable  armorclaude${N}
   ${D}claude plugin update  armorclaude${N}
 
-EOF
+  Docs: ${C}https://github.com/armoriq/armorClaude${N}
 
-  printf "  Docs: ${C}https://github.com/armoriq/armorClaude${N}\n\n"
+EOF
 }
 
 # ---------------------------------------------------------------------------
@@ -340,8 +175,6 @@ main() {
   ok "prerequisites OK ($(claude --version 2>/dev/null | head -1), $(node --version))"
 
   install_plugin
-  api_key_step
-  persist_api_key
   verify_install
   finale
 }


### PR DESCRIPTION
## Why

The interactive API-key prompt added in #2/#3 made ArmorClaude look like it requires a backend account. The original v0.2.0 design (initial commit [fbc8aea](https://github.com/armoriq/armorClaude/commit/fbc8aea), Feb 27) explicitly documented `ARMORIQ_API_KEY` as **optional**.

Worse, end-to-end testing showed the key-flow pulled users straight into backend mode where a tenant-side OPA policy (`travily-policy`, `defaultEnforcementAction: block`, no allow rules) denies every tool call at issuance time. The local-only path doesn't have this problem.

## What this does

| Before | After |
|---|---|
| Banner → prereqs → install → "Do you have a key?" prompt → paste/validate/save → exec claude | Banner → prereqs → install → done |
| 350 lines | 182 lines |

API key is now documented as an opt-in footer:

```
┃ Optional: connect to ArmorIQ
  1. Get an API key at https://dev.armoriq.ai
  2. export ARMORIQ_API_KEY=ak_live_...
  3. Open a new terminal and run claude
```

## Removed

- `prompt_secret()`, `prompt_yes_no()` helpers
- API-key validation + 3-attempt retry loop
- `~/.zshrc` / `~/.bashrc` / `~/.bash_profile` persistence
- `exec env claude` auto-launch
- `ARMORCLAUDE_HIDE_KEY` / `ARMORCLAUDE_SKIP_KEY` / `ARMORCLAUDE_NO_PROMPT` overrides
- `ARMORIQ_API_KEY` env-var detection at install time

## Test plan

- [x] Install with `ARMORCLAUDE_MARKETPLACE_REPO=...` → no prompts, `armorclaude@armoriq` enabled
- [x] `claude` session — `register_intent_plan` produces `Intent registered: 1 steps. No ArmorIQ backend configured — plan stored locally.`
- [x] `Read README.md` → allowed (in plan)
- [x] `ls /etc` with bash → new plan registered → allowed
- [x] `Policy new: deny WebFetch` → policy stored, version 1
- [x] `Fetch https://example.com` → `ArmorCowork policy deny: policy1`
- [x] `policy list` → shows the deny rule

## Follow-up (not blocking this PR)

Backend bug — `IAPIntentPlan.status` stays `'failed'` after OPA denial even when audit logs report success. Fix written for `enterprise/conmap-auto/src/iap/iap.service.ts:updateExecutionProgress`. Separate repo, separate deploy.