### PR TITLE
perf: auto-refresh intent token + cheaper PreToolUse hot path

### DIFF
--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -90,9 +90,17 @@ export function loadConfig(env = process.env) {
     verifyStepEndpoint:
       env.ARMORCOWORK_VERIFY_STEP_URL?.trim() ||
       `${backendEndpoint}/iap/verify-step`,
-    validitySeconds: parseInteger(env.ARMORCOWORK_VALIDITY_SECONDS, 60),
+    // 10 minutes is long enough for multi-step agentic work without forcing
+    // a replan mid-turn. Set ARMORCOWORK_VALIDITY_SECONDS to tighten.
+    validitySeconds: parseInteger(env.ARMORCOWORK_VALIDITY_SECONDS, 600),
+    // Proactively refresh the intent token when it has less than this many
+    // seconds of life left, so tool calls don't hit the expiry boundary.
+    refreshThresholdSeconds: parseInteger(env.ARMORCOWORK_REFRESH_THRESHOLD_SECONDS, 30),
     timeoutMs,
-    maxRetries: parseInteger(env.ARMORCOWORK_MAX_RETRIES, 3),
+    // One attempt per tool call is usually right — a hung backend shouldn't
+    // stall Claude for timeout * retries. Users who really want retries can
+    // opt in via ARMORCOWORK_MAX_RETRIES.
+    maxRetries: parseInteger(env.ARMORCOWORK_MAX_RETRIES, 1),
     verifySsl: parseBoolean(env.ARMORCOWORK_VERIFY_SSL, true),
     llmId: env.ARMORCOWORK_LLM_ID?.trim() || "claude-code",
     mcpName: env.ARMORCOWORK_MCP_NAME?.trim() || "claude-code",

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -1,4 +1,4 @@
-import { normalizeToolName, nowEpochSeconds, redactSecrets, sanitizeParams } from "./common.mjs";
+import { isPlainObject, normalizeToolName, nowEpochSeconds, redactSecrets, sanitizeParams } from "./common.mjs";
 import { addPromptContext, blockPrompt, denyPreTool } from "./hook-output.mjs";
 import {
   checkIntentTokenPlan,
@@ -291,11 +291,13 @@ export async function handlePreToolUse(input, config) {
   // Always consume if a pending file exists — the MCP handler only writes
   // it when Claude has registered a NEW plan, and stale plans must be
   // overwritten so each prompt gets its own plan boundary.
-  const runtimeStateEarly = await loadRuntimeState(config.runtimeFile);
+  // This load is reused for the rest of the PreToolUse handler instead of
+  // reloading from disk below (fewer disk reads on the hot path).
+  const runtimeState = await loadRuntimeState(config.runtimeFile);
   const pendingPath = path.join(config.dataDir, "pending-plan.json");
   const pending = await readJson(pendingPath, null);
   if (pending && (pending.tokenRaw || pending.plan)) {
-    upsertSession(runtimeStateEarly, sessionId, {
+    upsertSession(runtimeState, sessionId, {
       intentTokenRaw: pending.tokenRaw || "",
       plan: pending.plan,
       allowedActions: Array.isArray(pending.allowedActions) ? pending.allowedActions : [],
@@ -303,7 +305,7 @@ export async function handlePreToolUse(input, config) {
       // Reset per-token execution tracking when a new plan replaces the old.
       intentExecution: undefined
     });
-    await saveRuntimeState(config.runtimeFile, runtimeStateEarly);
+    await saveRuntimeState(config.runtimeFile, runtimeState);
     await unlink(pendingPath).catch(() => {});
     debugLog(config, "consumed pending plan from register_intent_plan");
   }
@@ -339,7 +341,7 @@ export async function handlePreToolUse(input, config) {
   }
 
   // --- Intent token verification ---
-  const runtimeState = await loadRuntimeState(config.runtimeFile);
+  // Reuse the runtimeState loaded above instead of re-reading from disk.
   const session = getSession(runtimeState, sessionId) || {};
   let intentTokenRaw = readIntentTokenRaw(input, session);
   let localPlan = session.plan;
@@ -350,6 +352,50 @@ export async function handlePreToolUse(input, config) {
     intentTokenRaw && localPlan
       ? getSessionTokenUsedStepIndices(session, intentTokenRaw)
       : undefined;
+
+  // Proactive refresh: if the token is about to expire and we still have the
+  // plan, re-issue silently so the user never sees a "token expired" deny in
+  // the middle of a multi-step turn. If the refresh fails, flow falls through
+  // to the existing expiry check below.
+  const refreshThreshold = Number.isFinite(config.refreshThresholdSeconds)
+    ? config.refreshThresholdSeconds
+    : 30;
+  if (
+    intentTokenRaw &&
+    isPlainObject(localPlan) &&
+    Number.isFinite(localExpiresAt) &&
+    localExpiresAt - nowEpochSeconds() < refreshThreshold &&
+    (config.intentEndpoint || (config.useSdkIntent && config.apiKey))
+  ) {
+    try {
+      const policyHash = computePolicyHash(policyState.policy);
+      const refreshed = await requestIntent(config, {
+        prompt: session.lastPrompt || `Refresh intent for ${toolName}`,
+        plan: localPlan,
+        session_id: sessionId,
+        toolName,
+        toolInput,
+        policy_hash: policyHash,
+        policy: policyState.policy,
+        validitySeconds: config.validitySeconds,
+        metadata: { source: "claude-code", trigger: "auto_refresh" }
+      });
+      if (!refreshed.skipped) {
+        const merged = mergeIntentIntoSession(session, refreshed);
+        upsertSession(runtimeState, sessionId, merged);
+        intentTokenRaw =
+          typeof merged.intentTokenRaw === "string"
+            ? merged.intentTokenRaw
+            : intentTokenRaw;
+        localPlan = merged.plan || localPlan;
+        localExpiresAt = merged.expiresAt || localExpiresAt;
+        debugLog(config, "intent token auto-refreshed near expiry");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      debugLog(config, `auto-refresh failed: ${message}`);
+    }
+  }
 
   // If no token, try to acquire one
   if (!intentTokenRaw && (config.intentEndpoint || (config.useSdkIntent && config.apiKey))) {
@@ -468,7 +514,10 @@ export async function handlePreToolUse(input, config) {
 
   // --- Expiry check ---
   if (Number.isFinite(localExpiresAt) && nowEpochSeconds() > localExpiresAt) {
-    const deny = denyOrAllow(config, "ArmorClaude intent token expired");
+    const deny = denyOrAllow(
+      config,
+      "ArmorClaude intent token expired — call register_intent_plan with your current plan to refresh, then retry the tool"
+    );
     if (deny) {
       return deny;
     }

--- a/scripts/lib/intent.mjs
+++ b/scripts/lib/intent.mjs
@@ -236,7 +236,12 @@ export function checkIntentTokenPlan({ intentTokenRaw, toolName, toolParams }) {
     return { matched: false };
   }
   if (parsed.expiresAt && Date.now() / 1000 > parsed.expiresAt) {
-    return { matched: true, blockReason: "ArmorIQ intent token expired", plan: parsed.plan };
+    return {
+      matched: true,
+      blockReason:
+        "ArmorIQ intent token expired — call register_intent_plan to refresh, then retry",
+      plan: parsed.plan
+    };
   }
   const allowedActions = extractAllowedActions(parsed.plan);
   if (!allowedActions.has(normalizeToolName(toolName))) {


### PR DESCRIPTION
> Stacked on top of #6. Merge #6 first, then rebase this onto main.

## Summary

Phase 1 + Phase 2 of the perf plan. Fixes the token-expiry retry loop users hit on multi-step turns, and shaves disk I/O from every tool call.

**Phase 1 — stop the expiry loop**
- Default `validitySeconds` 60s → 600s. One env var (`ARMORCOWORK_VALIDITY_SECONDS`) to tighten.
- Proactively refresh the intent token when it has less than `refreshThresholdSeconds` (default 30s) of life left. Reuses the stored plan, so the user sees no interruption.
- When refresh fails or the token is already dead, the expiry deny now tells Claude exactly how to recover (`call register_intent_plan with your current plan to refresh, then retry`) instead of the bare "intent token expired" that triggered infinite retries on the same tool.

**Phase 2 — cheaper hot path**
- `handlePreToolUse` used to load `runtime.json` twice per call. Collapsed to a single load; later steps reuse the in-memory state.
- Default `maxRetries` 3 → 1. A hung backend stalling Claude for `timeout × 3` is worse than one fast failure.

## Files
| File | Change |
|------|--------|
| `scripts/lib/config.mjs` | new defaults + `refreshThresholdSeconds` |
| `scripts/lib/engine.mjs` | auto-refresh block, single runtime load, actionable expiry reason |
| `scripts/lib/intent.mjs` | actionable expiry reason on token-plan check |

## Test plan
- [x] `node --test tests/*.test.mjs` — 49/49 pass
- [x] TTL default verified as 600s via config smoke test
- [x] Env overrides still honored
- [x] Expiry deny message contains recovery instruction
- [x] Happy-path allow / drift deny / fail-closed all still work
- [ ] Live session on staging — multi-step turn no longer hits the retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)