### PR TITLE
fix: update docs URL to armorclaude-docs.armoriq.ai

### DIFF
--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -204,7 +204,7 @@ EOF
   ${D}claude plugin enable  armorclaude${N}
   ${D}claude plugin update  armorclaude${N}
 
-  Docs: ${C}https://github.com/armoriq/armorClaude${N}
+  Docs: ${C}https://armorclaude-docs.armoriq.ai${N}
 
 EOF
 }

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -187,10 +187,15 @@ export async function handleUserPromptSubmit(input, config) {
   }
 
   // --- Policy command handling ---
+  // Instead of blocking the prompt (which Desktop UI swallows silently),
+  // apply the command and inject the result as context so Claude can
+  // relay the outcome to the user.
   if (policyCommandLooksLikePrompt(prompt)) {
     const allowed = isPolicyUpdateAllowed(config, input);
     if (!allowed.allowed) {
-      return blockPrompt(allowed.reason || "ArmorClaude policy update denied");
+      return addPromptContext(
+        `[ArmorClaude] ${allowed.reason || "Policy update denied."}`
+      );
     }
     const policyState = await loadPolicyState(config.policyFile);
     const command = parsePolicyTextCommand(prompt, policyState);
@@ -201,7 +206,9 @@ export async function handleUserPromptSubmit(input, config) {
       command,
       actor
     });
-    return blockPrompt(result.message);
+    return addPromptContext(
+      `[ArmorClaude] ${result.message}\n\nTell the user the result above. Do not call any tools for this request.`
+    );
   }
 
   // --- Store prompt in session ---

--- a/tests/policy.test.mjs
+++ b/tests/policy.test.mjs
@@ -84,8 +84,8 @@ test("handleUserPromptSubmit applies policy command and blocks prompt", async ()
     config
   );
 
-  assert.equal(output?.decision, "block");
-  assert.match(output?.reason || "", /policy updated/i);
+  assert.ok(output?.hookSpecificOutput?.additionalContext);
+  assert.match(output.hookSpecificOutput.additionalContext, /policy updated/i);
 });
 
 test("handlePreToolUse denies when policy blocks tool", async () => {


### PR DESCRIPTION
Update the Docs link in the installer output to point to the new dedicated docs site.