### PR TITLE
chore: finish armorcowork→armorclaude rename

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,7 +50,7 @@ Now try a prompt that goes off-plan:
 Claude will register a plan with `Read` only (or `Read` + `Bash` if it's smart). If it tries `Bash` without declaring it:
 
 ```
-✘ ArmorCowork intent drift: tool not in plan (Bash)
+✘ ArmorClaude intent drift: tool not in plan (Bash)
 ```
 
 That's intent enforcement, with no backend, no API key, no extra LLM call.
@@ -121,7 +121,7 @@ claude plugin disable armorclaude
 **Want monitor mode (log only, never block)?**
 
 ```bash
-ARMORCOWORK_MODE=monitor claude
+ARMORCLAUDE_MODE=monitor claude
 ```
 
 Or set it via `/plugin` → configure → `mode: monitor`.

--- a/README.md
+++ b/README.md
@@ -109,31 +109,31 @@ When installed as a Claude Code plugin, these values are prompted on enable:
 **Core:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARMORCOWORK_MODE` | `enforce` | `enforce` blocks on failure, `monitor` logs only |
-| `ARMORCOWORK_INTENT_REQUIRED` | `true` | Block tool calls with no intent token |
-| `ARMORCOWORK_DATA_DIR` | `$CLAUDE_PLUGIN_DATA` or `~/.claude/armorcowork` | Data storage directory |
-| `ARMORCOWORK_DEBUG` | `false` | Enable stderr debug logging |
+| `ARMORCLAUDE_MODE` | `enforce` | `enforce` blocks on failure, `monitor` logs only |
+| `ARMORCLAUDE_INTENT_REQUIRED` | `true` | Block tool calls with no intent token |
+| `ARMORCLAUDE_DATA_DIR` | `$CLAUDE_PLUGIN_DATA` or `~/.claude/armorclaude` | Data storage directory |
+| `ARMORCLAUDE_DEBUG` | `false` | Enable stderr debug logging |
 
 **ArmorIQ Integration:**
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ARMORIQ_API_KEY` | — | ArmorIQ SDK API key |
-| `ARMORCOWORK_USE_SDK_INTENT` | `true` | Use ArmorIQ SDK for intent capture |
-| `ARMORCOWORK_INTENT_URL` | — | Custom intent endpoint (overrides SDK) |
-| `ARMORCOWORK_VERIFY_STEP_URL` | `<backend>/iap/verify-step` | IAP verify endpoint |
-| `ARMORCOWORK_BACKEND_ENDPOINT` | production or localhost | IAP backend URL |
-| `ARMORCOWORK_IAP_ENDPOINT` | production or localhost | CSRG service URL |
-| `ARMORCOWORK_VALIDITY_SECONDS` | `60` | Intent token TTL |
+| `ARMORCLAUDE_USE_SDK_INTENT` | `true` | Use ArmorIQ SDK for intent capture |
+| `ARMORCLAUDE_INTENT_URL` | — | Custom intent endpoint (overrides SDK) |
+| `ARMORCLAUDE_VERIFY_STEP_URL` | `<backend>/iap/verify-step` | IAP verify endpoint |
+| `ARMORCLAUDE_BACKEND_ENDPOINT` | production or localhost | IAP backend URL |
+| `ARMORCLAUDE_IAP_ENDPOINT` | production or localhost | CSRG service URL |
+| `ARMORCLAUDE_VALIDITY_SECONDS` | `60` | Intent token TTL |
 
 **Plan Directive:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARMORCOWORK_PLANNING_ENABLED` | `true` | Inject directive telling Claude to register an intent plan |
+| `ARMORCLAUDE_PLANNING_ENABLED` | `true` | Inject directive telling Claude to register an intent plan |
 
 **Crypto Policy Binding:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARMORCOWORK_CRYPTO_POLICY_ENABLED` | `false` | Merkle tree policy binding |
+| `ARMORCLAUDE_CRYPTO_POLICY_ENABLED` | `false` | Merkle tree policy binding |
 | `CSRG_URL` | IAP endpoint | CSRG service URL |
 | `REQUIRE_CSRG_PROOFS` | `true` | Require cryptographic proofs |
 | `CSRG_VERIFY_ENABLED` | `true` | Enable CSRG verification |
@@ -141,13 +141,13 @@ When installed as a Claude Code plugin, these values are prompted on enable:
 **Audit Logging:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARMORCOWORK_AUDIT_ENABLED` | `true` (when API key set) | Send audit logs to IAP |
+| `ARMORCLAUDE_AUDIT_ENABLED` | `true` (when API key set) | Send audit logs to IAP |
 
 **Policy Management:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ARMORCOWORK_POLICY_UPDATE_ENABLED` | `true` | Allow runtime policy updates |
-| `ARMORCOWORK_POLICY_UPDATE_ALLOWLIST` | `*` | CSV of allowed actors |
+| `ARMORCLAUDE_POLICY_UPDATE_ENABLED` | `true` | Allow runtime policy updates |
+| `ARMORCLAUDE_POLICY_UPDATE_ALLOWLIST` | `*` | CSV of allowed actors |
 
 ## Hook Events
 
@@ -163,10 +163,10 @@ When installed as a Claude Code plugin, these values are prompted on enable:
 
 ## Plan Generation
 
-ArmorCowork supports two plan generation strategies:
+ArmorClaude supports two plan generation strategies:
 
 ### 1. Claude's Built-in Plan Mode (primary)
-When Claude operates in plan mode, it writes a plan file and calls `ExitPlanMode`. ArmorCowork intercepts `ExitPlanMode` via the `PreToolUse` hook, parses the plan file, and sends it to ArmorIQ for intent token generation.
+When Claude operates in plan mode, it writes a plan file and calls `ExitPlanMode`. ArmorClaude intercepts `ExitPlanMode` via the `PreToolUse` hook, parses the plan file, and sends it to ArmorIQ for intent token generation.
 
 ### 2. MCP Tool (when plan mode is off)
 A directive injected via `UserPromptSubmit` instructs Claude to call `register_intent_plan` as its first tool call. Claude produces the plan as the tool's arguments — using its own LLM in the same turn, with no separate API key or extra LLM call. The MCP tool handler sends the plan to ArmorIQ for a signed intent token.

--- a/design.md
+++ b/design.md
@@ -1,8 +1,8 @@
-# ArmorCowork — Design Document
+# ArmorClaude — Design Document
 
 ## Overview
 
-ArmorCowork is a security plugin for Claude Code / Claude Cowork that enforces intent-based access control on tool calls. It is the Claude Code equivalent of ArmorClaw (for OpenClaw).
+ArmorClaude is a security plugin for Claude Code / Claude Cowork that enforces intent-based access control on tool calls. It is the Claude Code equivalent of ArmorClaw (for OpenClaw).
 
 Core idea: an AI agent declares what it intends to do before doing it, and every action is checked against that declared intent. This prevents prompt injection from causing unauthorized tool use, blocks data exfiltration, and provides an audit trail of every tool call decision.
 
@@ -111,7 +111,7 @@ If any of the following occurs in enforce mode, all tool calls are blocked:
 - IAP verify-step returns denied
 - Internal error in the hook
 
-Monitor mode (`ARMORCOWORK_MODE=monitor`) logs these events but allows tool calls to proceed.
+Monitor mode (`ARMORCLAUDE_MODE=monitor`) logs these events but allows tool calls to proceed.
 
 ## Module Responsibilities
 
@@ -161,7 +161,7 @@ Hooks are stateless short-lived processes (new Node process per event). All stat
 
 ## Comparison with ArmorClaw
 
-| Feature | ArmorClaw (OpenClaw) | ArmorCowork (Claude Code) |
+| Feature | ArmorClaw (OpenClaw) | ArmorClaude (Claude Code) |
 |---------|---------------------|--------------------------|
 | Plan generation | Separate LLM call via pi-ai | Claude's own LLM via MCP tool / plan mode |
 | Plan API key | Uses agent's runtime.modelAuth | None needed (session LLM) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "armorcowork",
+  "name": "armorclaude",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "armorcowork",
+      "name": "armorclaude",
       "version": "0.1.0",
       "dependencies": {
         "@armoriq/sdk": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "armorcowork",
+  "name": "armorclaude",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/scripts/hook-router.mjs
+++ b/scripts/hook-router.mjs
@@ -26,7 +26,7 @@ function debugLog(config, message) {
   if (!config.debug) {
     return;
   }
-  process.stderr.write(`[armorcowork] ${message}\n`);
+  process.stderr.write(`[armorclaude] ${message}\n`);
 }
 
 async function main() {
@@ -97,7 +97,7 @@ main().catch((error) => {
     // fail-closed: default to enforce rather than a silent allow.
   }
   if (debug) {
-    process.stderr.write(`[armorcowork] error=${message}\n`);
+    process.stderr.write(`[armorclaude] error=${message}\n`);
   }
   if (mode === "enforce") {
     emitJson(denyPreTool(`ArmorClaude internal error: ${message}`));

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -5,7 +5,7 @@ import { parseBoolean, parseInteger, parseList } from "./common.mjs";
 
 /**
  * Read a config value from CLAUDE_PLUGIN_OPTION_* (injected by Claude Code
- * plugin userConfig), falling back to the legacy ARMORCOWORK_* env var.
+ * plugin userConfig), falling back to the legacy ARMORCLAUDE_* env var.
  */
 function pluginOpt(env, pluginKey, legacyKey) {
   const pluginVal = env[`CLAUDE_PLUGIN_OPTION_${pluginKey}`]?.trim();
@@ -15,43 +15,43 @@ function pluginOpt(env, pluginKey, legacyKey) {
 }
 
 export function loadConfig(env = process.env) {
-  const mode = (pluginOpt(env, "MODE", "ARMORCOWORK_MODE") || "enforce").toLowerCase();
+  const mode = (pluginOpt(env, "MODE", "ARMORCLAUDE_MODE") || "enforce").toLowerCase();
   const envMode = (env.ARMORIQ_ENV || "production").trim().toLowerCase();
   const useProduction = parseBoolean(
-    pluginOpt(env, "USE_PRODUCTION", "ARMORCOWORK_USE_PRODUCTION") || undefined,
+    pluginOpt(env, "USE_PRODUCTION", "ARMORCLAUDE_USE_PRODUCTION") || undefined,
     envMode === "production"
   );
 
   // Data directory: prefer CLAUDE_PLUGIN_DATA (Claude Code injected), then
-  // ARMORCOWORK_DATA_DIR, then default ~/.claude/armorcowork
+  // ARMORCLAUDE_DATA_DIR, then default ~/.claude/armorclaude
   const dataDir =
     env.CLAUDE_PLUGIN_DATA?.trim() ||
-    env.ARMORCOWORK_DATA_DIR?.trim() ||
-    path.join(homedir(), ".claude", "armorcowork");
+    env.ARMORCLAUDE_DATA_DIR?.trim() ||
+    path.join(homedir(), ".claude", "armorclaude");
 
   const policyFile =
-    env.ARMORCOWORK_POLICY_FILE?.trim() || path.join(dataDir, "policy.json");
+    env.ARMORCLAUDE_POLICY_FILE?.trim() || path.join(dataDir, "policy.json");
   const runtimeFile =
-    env.ARMORCOWORK_RUNTIME_FILE?.trim() || path.join(dataDir, "runtime.json");
+    env.ARMORCLAUDE_RUNTIME_FILE?.trim() || path.join(dataDir, "runtime.json");
 
-  const timeoutMs = parseInteger(env.ARMORCOWORK_TIMEOUT_MS, 8000);
+  const timeoutMs = parseInteger(env.ARMORCLAUDE_TIMEOUT_MS, 8000);
 
   const backendEndpoint =
-    env.ARMORCOWORK_BACKEND_ENDPOINT?.trim() ||
+    env.ARMORCLAUDE_BACKEND_ENDPOINT?.trim() ||
     env.BACKEND_ENDPOINT?.trim() ||
     (useProduction
       ? "https://staging-api.armoriq.ai"
       : "http://127.0.0.1:3000");
 
   const iapEndpoint =
-    env.ARMORCOWORK_IAP_ENDPOINT?.trim() ||
+    env.ARMORCLAUDE_IAP_ENDPOINT?.trim() ||
     env.IAP_ENDPOINT?.trim() ||
     (useProduction
       ? "https://iap.armoriq.ai"
       : "http://127.0.0.1:8000");
 
   const proxyEndpoint =
-    env.ARMORCOWORK_PROXY_ENDPOINT?.trim() ||
+    env.ARMORCLAUDE_PROXY_ENDPOINT?.trim() ||
     env.PROXY_ENDPOINT?.trim() ||
     (useProduction
       ? "https://cloud-run-proxy.armoriq.io"
@@ -85,32 +85,32 @@ export function loadConfig(env = process.env) {
     proxyEndpoint,
     csrgEndpoint,
     apiKey,
-    useSdkIntent: parseBoolean(env.ARMORCOWORK_USE_SDK_INTENT, true),
-    intentEndpoint: env.ARMORCOWORK_INTENT_URL?.trim() || "",
+    useSdkIntent: parseBoolean(env.ARMORCLAUDE_USE_SDK_INTENT, true),
+    intentEndpoint: env.ARMORCLAUDE_INTENT_URL?.trim() || "",
     verifyStepEndpoint:
-      env.ARMORCOWORK_VERIFY_STEP_URL?.trim() ||
+      env.ARMORCLAUDE_VERIFY_STEP_URL?.trim() ||
       `${backendEndpoint}/iap/verify-step`,
     // 10 minutes is long enough for multi-step agentic work without forcing
-    // a replan mid-turn. Set ARMORCOWORK_VALIDITY_SECONDS to tighten.
-    validitySeconds: parseInteger(env.ARMORCOWORK_VALIDITY_SECONDS, 600),
+    // a replan mid-turn. Set ARMORCLAUDE_VALIDITY_SECONDS to tighten.
+    validitySeconds: parseInteger(env.ARMORCLAUDE_VALIDITY_SECONDS, 600),
     // Proactively refresh the intent token when it has less than this many
     // seconds of life left, so tool calls don't hit the expiry boundary.
-    refreshThresholdSeconds: parseInteger(env.ARMORCOWORK_REFRESH_THRESHOLD_SECONDS, 30),
+    refreshThresholdSeconds: parseInteger(env.ARMORCLAUDE_REFRESH_THRESHOLD_SECONDS, 30),
     timeoutMs,
     // One attempt per tool call is usually right — a hung backend shouldn't
     // stall Claude for timeout * retries. Users who really want retries can
-    // opt in via ARMORCOWORK_MAX_RETRIES.
-    maxRetries: parseInteger(env.ARMORCOWORK_MAX_RETRIES, 1),
-    verifySsl: parseBoolean(env.ARMORCOWORK_VERIFY_SSL, true),
-    llmId: env.ARMORCOWORK_LLM_ID?.trim() || "claude-code",
-    mcpName: env.ARMORCOWORK_MCP_NAME?.trim() || "claude-code",
-    userId: env.ARMORCOWORK_USER_ID?.trim() || "claude-user",
-    agentId: env.ARMORCOWORK_AGENT_ID?.trim() || "claude-code",
-    contextId: env.ARMORCOWORK_CONTEXT_ID?.trim() || "default",
+    // opt in via ARMORCLAUDE_MAX_RETRIES.
+    maxRetries: parseInteger(env.ARMORCLAUDE_MAX_RETRIES, 1),
+    verifySsl: parseBoolean(env.ARMORCLAUDE_VERIFY_SSL, true),
+    llmId: env.ARMORCLAUDE_LLM_ID?.trim() || "claude-code",
+    mcpName: env.ARMORCLAUDE_MCP_NAME?.trim() || "claude-code",
+    userId: env.ARMORCLAUDE_USER_ID?.trim() || "claude-user",
+    agentId: env.ARMORCLAUDE_AGENT_ID?.trim() || "claude-code",
+    contextId: env.ARMORCLAUDE_CONTEXT_ID?.trim() || "default",
 
     // Intent enforcement — default true (enforce plan mode)
     intentRequired: parseBoolean(
-      pluginOpt(env, "INTENT_REQUIRED", "ARMORCOWORK_INTENT_REQUIRED") || undefined,
+      pluginOpt(env, "INTENT_REQUIRED", "ARMORCLAUDE_INTENT_REQUIRED") || undefined,
       true
     ),
     // CSRG verification disabled by default until tenant OPA policies are
@@ -121,38 +121,38 @@ export function loadConfig(env = process.env) {
     csrgVerifyEnabled: parseBoolean(env.CSRG_VERIFY_ENABLED, false),
 
     // Policy management
-    policyUpdateEnabled: parseBoolean(env.ARMORCOWORK_POLICY_UPDATE_ENABLED, true),
+    policyUpdateEnabled: parseBoolean(env.ARMORCLAUDE_POLICY_UPDATE_ENABLED, true),
     policyUpdateAllowList: parseList(
-      env.ARMORCOWORK_POLICY_UPDATE_ALLOWLIST || "*"
+      env.ARMORCLAUDE_POLICY_UPDATE_ALLOWLIST || "*"
     ),
     contextHintsEnabled: parseBoolean(
-      env.ARMORCOWORK_CONTEXT_HINTS_ENABLED,
+      env.ARMORCLAUDE_CONTEXT_HINTS_ENABLED,
       true
     ),
 
     // Crypto policy binding (Merkle tree)
     cryptoPolicyEnabled: parseBoolean(
-      pluginOpt(env, "CRYPTO_POLICY_ENABLED", "ARMORCOWORK_CRYPTO_POLICY_ENABLED") || undefined,
+      pluginOpt(env, "CRYPTO_POLICY_ENABLED", "ARMORCLAUDE_CRYPTO_POLICY_ENABLED") || undefined,
       false
     ),
 
     // Audit logging
     auditEnabled: parseBoolean(
-      env.ARMORCOWORK_AUDIT_ENABLED,
+      env.ARMORCLAUDE_AUDIT_ENABLED,
       Boolean(apiKey)
     ),
 
     // Plan directive injection (tells Claude to register a plan via MCP tool)
-    planningEnabled: parseBoolean(env.ARMORCOWORK_PLANNING_ENABLED, true),
+    planningEnabled: parseBoolean(env.ARMORCLAUDE_PLANNING_ENABLED, true),
 
     // Param sanitization limits
     sanitize: {
-      maxChars: parseInteger(env.ARMORCOWORK_MAX_PARAM_CHARS, 2000),
-      maxDepth: parseInteger(env.ARMORCOWORK_MAX_PARAM_DEPTH, 4),
-      maxKeys: parseInteger(env.ARMORCOWORK_MAX_PARAM_KEYS, 50),
-      maxItems: parseInteger(env.ARMORCOWORK_MAX_PARAM_ITEMS, 50)
+      maxChars: parseInteger(env.ARMORCLAUDE_MAX_PARAM_CHARS, 2000),
+      maxDepth: parseInteger(env.ARMORCLAUDE_MAX_PARAM_DEPTH, 4),
+      maxKeys: parseInteger(env.ARMORCLAUDE_MAX_PARAM_KEYS, 50),
+      maxItems: parseInteger(env.ARMORCLAUDE_MAX_PARAM_ITEMS, 50)
     },
 
-    debug: parseBoolean(env.ARMORCOWORK_DEBUG, false)
+    debug: parseBoolean(env.ARMORCLAUDE_DEBUG, false)
   };
 }

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -132,7 +132,7 @@ function denyOrAllow(config, reason) {
 
 function debugLog(config, message) {
   if (config.debug) {
-    process.stderr.write(`[armorcowork] ${message}\n`);
+    process.stderr.write(`[armorclaude] ${message}\n`);
   }
 }
 

--- a/scripts/policy-mcp.mjs
+++ b/scripts/policy-mcp.mjs
@@ -71,7 +71,7 @@ async function loadStateAndConfig() {
 
 async function run() {
   const server = new McpServer({
-    name: "armorcowork-policy",
+    name: "armorclaude-policy",
     version: "0.1.0"
   });
 
@@ -208,7 +208,7 @@ async function run() {
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          process.stderr.write(`[armorcowork] intent capture in register_intent_plan: ${msg}\n`);
+          process.stderr.write(`[armorclaude] intent capture in register_intent_plan: ${msg}\n`);
         }
       }
 
@@ -239,7 +239,7 @@ async function run() {
 
 run().catch((error) => {
   const message = error instanceof Error ? error.stack || error.message : String(error);
-  process.stderr.write(`[armorcowork-policy] ${message}\n`);
+  process.stderr.write(`[armorclaude-policy] ${message}\n`);
   process.exitCode = 1;
 });
 

--- a/tests/crypto-policy.test.mjs
+++ b/tests/crypto-policy.test.mjs
@@ -31,7 +31,7 @@ test("computePolicyDigest handles empty rules", () => {
 });
 
 test("verifyPolicyDigest returns valid on match", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
@@ -48,7 +48,7 @@ test("verifyPolicyDigest returns valid on match", async () => {
 });
 
 test("verifyPolicyDigest returns invalid on mismatch", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
@@ -65,7 +65,7 @@ test("verifyPolicyDigest returns invalid on mismatch", async () => {
 });
 
 test("verifyPolicyDigest returns invalid when no token digest", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
@@ -79,7 +79,7 @@ test("verifyPolicyDigest returns invalid when no token digest", async () => {
 });
 
 test("loadCachedState returns null when no state file", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",

--- a/tests/intent.test.mjs
+++ b/tests/intent.test.mjs
@@ -97,7 +97,7 @@ test("resolveCsrgProofsFromToken selects param-matched step for duplicate tools"
 });
 
 test("iapService.verifyStep sends payload with jwt token and CSRG context", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, {
     verifyStepEndpoint: "https://example.test/iap/verify-step"
   });
@@ -196,7 +196,7 @@ test("checkIntentTokenPlan enforces parameter constraints", () => {
 });
 
 test("handlePreToolUse resolves CSRG proofs from token step_proofs across duplicate tools", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, {
     verifyStepEndpoint: "https://example.test/iap/verify-step"
   });

--- a/tests/lifecycle.test.mjs
+++ b/tests/lifecycle.test.mjs
@@ -57,7 +57,7 @@ function buildConfig(tmpDir, overrides = {}) {
 }
 
 test("handleSessionStart creates session and returns context", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp);
   const output = await handleSessionStart(
     { hook_event_name: "SessionStart", session_id: "sess-1", source: "startup" },
@@ -74,7 +74,7 @@ test("handleSessionStart creates session and returns context", async () => {
 });
 
 test("handleSessionEnd removes session", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp);
   // Create session first
   await handleSessionStart(
@@ -93,7 +93,7 @@ test("handleSessionEnd removes session", async () => {
 });
 
 test("handleStop returns null", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp);
   await handleSessionStart(
     { hook_event_name: "SessionStart", session_id: "sess-3" },
@@ -107,7 +107,7 @@ test("handleStop returns null", async () => {
 });
 
 test("handlePostToolUse returns null when audit disabled", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { auditEnabled: false });
   const output = await handlePostToolUse(
     {
@@ -123,7 +123,7 @@ test("handlePostToolUse returns null when audit disabled", async () => {
 });
 
 test("handlePostToolUse sends audit when enabled", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { auditEnabled: true, apiKey: "test-key" });
   await handleSessionStart(
     { hook_event_name: "SessionStart", session_id: "sess-5" },
@@ -160,7 +160,7 @@ test("handlePostToolUse sends audit when enabled", async () => {
 });
 
 test("handlePostToolUseFailure logs failed status", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { auditEnabled: true, apiKey: "test-key" });
   await handleSessionStart(
     { hook_event_name: "SessionStart", session_id: "sess-6" },

--- a/tests/policy.test.mjs
+++ b/tests/policy.test.mjs
@@ -73,7 +73,7 @@ test("checkToolAgainstPlan rejects tool drift", () => {
 });
 
 test("handleUserPromptSubmit applies policy command and blocks prompt", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp);
   const output = await handleUserPromptSubmit(
     {
@@ -89,7 +89,7 @@ test("handleUserPromptSubmit applies policy command and blocks prompt", async ()
 });
 
 test("handlePreToolUse denies when policy blocks tool", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp);
   await handleUserPromptSubmit(
     {
@@ -113,7 +113,7 @@ test("handlePreToolUse denies when policy blocks tool", async () => {
 });
 
 test("handlePreToolUse denies missing intent when strict", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { intentRequired: true });
   const output = await handlePreToolUse(
     {
@@ -129,7 +129,7 @@ test("handlePreToolUse denies missing intent when strict", async () => {
 });
 
 test("handlePreToolUse allows tool when local plan matches (no backend)", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { intentRequired: true });
   // Seed a local plan as if register_intent_plan had been called
   const { writeFile } = await import("node:fs/promises");
@@ -159,7 +159,7 @@ test("handlePreToolUse allows tool when local plan matches (no backend)", async 
 });
 
 test("handlePreToolUse denies drift when local plan exists (no backend)", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { intentRequired: true });
   const { writeFile } = await import("node:fs/promises");
   await writeFile(
@@ -189,7 +189,7 @@ test("handlePreToolUse denies drift when local plan exists (no backend)", async 
 });
 
 test("handlePreToolUse replaces stale local plan with fresh pending-plan.json", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { intentRequired: true });
   const { writeFile } = await import("node:fs/promises");
   // Seed an old "Read"-only plan in the session
@@ -230,7 +230,7 @@ test("handlePreToolUse replaces stale local plan with fresh pending-plan.json", 
 });
 
 test("handleUserPromptSubmit adds context hints for normal prompts", async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorcowork-test-"));
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { contextHintsEnabled: true, policyUpdateEnabled: true });
   const output = await handleUserPromptSubmit(
     {


### PR DESCRIPTION
## Summary
- Sweeps the leftovers from the earlier rename (5122764), which only covered user-facing strings: `ARMORCOWORK_*` env vars, hook-router log prefix, `package(-lock).json` name, test tmpdir prefixes, and the MCP server name in `scripts/policy-mcp.mjs`.
- Incidentally fixes a latent mismatch: `policy-mcp.mjs` was registering as `armorcowork-policy` while `engine.mjs`'s `armorMcpPrefix` expected `armorclaude-policy`. Both now agree.
- Repo directory itself renamed on disk: `projects/armorcowork` → `projects/armorclaude`. (Re-run the installer locally to refresh `~/.claude/plugins` from the new source location.)

## Breaking change
`ARMORCOWORK_*` env vars are renamed to `ARMORCLAUDE_*`. Plugin `userConfig` keys (the primary path per `pluginOpt(env, "<key>", "<env_var>")`) are unaffected — only direct env-var users are. CHANGELOG worth a line.

## Test plan
- [x] `npm test` — all 51 tests pass on the renamed paths
- [ ] Verify the plugin still loads after a local reinstall (`install_armorclaude.sh`)
- [ ] Spot-check that `mcp__plugin_armorclaude_armorclaude-policy__*` tools still resolve in a fresh Claude Code session
- [ ] Confirm no stragglers via `git ls-files | xargs grep -inE 'armor[-_ ]?cowork|ARMORCOWORK'` (currently empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)