### PR TITLE
feat(installer): pass --product armorclaude to login + policy matcher upgrades

### DIFF
--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -159,11 +159,22 @@ EOF
   fi
 
   echo
-  # Run armoriq login inline — uses the globally installed CLI or npx fallback
+  # Run armoriq login inline — uses the globally installed CLI or npx fallback.
+  # Pass --product so the browser approval page renders ArmorClaude branding.
+  # Older CLIs without --product fall back to a plain `armoriq login` invocation.
+  local product="armorclaude"
   if command -v armoriq >/dev/null 2>&1; then
-    armoriq login
+    if armoriq login --help 2>&1 | grep -q -- '--product'; then
+      armoriq login --product "${product}"
+    else
+      ARMORIQ_PRODUCT="${product}" armoriq login
+    fi
   elif command -v npx >/dev/null 2>&1; then
-    npx @armoriq/sdk-dev login
+    if npx @armoriq/sdk-dev login --help 2>&1 | grep -q -- '--product'; then
+      npx @armoriq/sdk-dev login --product "${product}"
+    else
+      ARMORIQ_PRODUCT="${product}" npx @armoriq/sdk-dev login
+    fi
   else
     warn "armoriq CLI not found. Run ${B}npx @armoriq/sdk-dev login${N} manually."
     return 0

--- a/scripts/lib/common.mjs
+++ b/scripts/lib/common.mjs
@@ -70,6 +70,191 @@ export function isSubsetValue(candidate, target) {
   return candidate === target;
 }
 
+// ---------------------------------------------------------------------------
+// Operator-based matcher — supports $contains, $startsWith, $endsWith,
+// $matches (regex), $pathContains (path-canonicalized substring), $equals.
+//
+// Rule fragments may use either a plain literal (exact match, same as
+// isSubsetValue behaviour) or an operator object: { $contains: "..." }.
+// ---------------------------------------------------------------------------
+
+const OPERATOR_KEYS = new Set([
+  "$equals",
+  "$contains",
+  "$startsWith",
+  "$endsWith",
+  "$matches",
+  "$pathContains"
+]);
+
+export function isMatcherSpec(value) {
+  if (!isPlainObject(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length === 0) return false;
+  return keys.every((k) => OPERATOR_KEYS.has(k));
+}
+
+// Canonicalize a path/string for $pathContains matching. Operates on free
+// text — the rule needle and the tool input may be a path like /etc/passwd,
+// a path-with-prefix like "ls -la ~/.ssh", or a tool param like file_path.
+// Rule: keep enough structure so substring match Just Works.
+function canonicalizePath(input) {
+  if (typeof input !== "string") return "";
+  let p = input.trim();
+  // ~ → $HOME (only when it appears at a path boundary so we don't mangle
+  // shell tokens like "echo ~hi").
+  p = p.replace(/(^|[\s"'`(=:])~(?=\/)/g, "$1$HOME");
+  // $HOME or ${HOME} → <HOME> sentinel
+  p = p.replace(/\$\{?HOME\}?/g, "<HOME>");
+  // Real home prefixes (Linux + macOS) → <HOME> sentinel so a rule mentioning
+  // ~/.ssh matches actual paths like /Users/foo/.ssh and /home/bar/.ssh.
+  p = p.replace(/\/(?:home|Users)\/[^/\s'"`)]+/gi, "<HOME>");
+  // Collapse repeated slashes, lowercase for case-insensitive substring.
+  p = p.replace(/\\/g, "/").replace(/\/+/g, "/");
+  return p.toLowerCase();
+}
+
+export function matchesScalar(spec, actual) {
+  // Plain literal — exact match (preserves existing behaviour).
+  if (!isMatcherSpec(spec)) {
+    return spec === actual;
+  }
+  if (typeof actual !== "string" && typeof actual !== "number") {
+    // Operator-based matchers only meaningful for strings/numbers.
+    return false;
+  }
+  const haystack = String(actual);
+  const haystackLower = haystack.toLowerCase();
+  for (const [op, raw] of Object.entries(spec)) {
+    const needle = typeof raw === "string" ? raw : String(raw);
+    const needleLower = needle.toLowerCase();
+    switch (op) {
+      case "$equals":
+        if (haystack !== needle) return false;
+        break;
+      case "$contains":
+        if (!haystackLower.includes(needleLower)) return false;
+        break;
+      case "$startsWith":
+        if (!haystackLower.startsWith(needleLower)) return false;
+        break;
+      case "$endsWith":
+        if (!haystackLower.endsWith(needleLower)) return false;
+        break;
+      case "$matches":
+        try {
+          const re = new RegExp(needle, "i");
+          if (!re.test(haystack)) return false;
+        } catch {
+          return false;
+        }
+        break;
+      case "$pathContains": {
+        const actualPath = canonicalizePath(haystack);
+        let needlePath = canonicalizePath(needle);
+        // Strip <home> prefix from the needle so a rule mentioning ~/.ssh
+        // also matches glob patterns like "**/.ssh/**" or relative-style
+        // paths that don't start at $HOME.
+        const homeStripped = needlePath.replace(/^<home>\/?/, "");
+        if (
+          actualPath.includes(needlePath) ||
+          (homeStripped && actualPath.includes(homeStripped))
+        ) {
+          break;
+        }
+        return false;
+      }
+      default:
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Recursive matcher for rule.params against actual tool input.
+ * Returns { matched, missingKeys } — missingKeys lists rule keys that have no
+ * counterpart in the tool input, so callers can surface "rule probably won't
+ * fire" warnings.
+ */
+export function matchParams(ruleParams, toolInput) {
+  if (ruleParams === undefined || ruleParams === null) {
+    return { matched: true, missingKeys: [] };
+  }
+  if (!isPlainObject(ruleParams)) {
+    return { matched: false, missingKeys: [] };
+  }
+  const target = isPlainObject(toolInput) ? toolInput : {};
+  const missingKeys = [];
+  for (const [key, value] of Object.entries(ruleParams)) {
+    const actualValue = target[key];
+    if (actualValue === undefined && !isMatcherSpec(value)) {
+      // Plain literal expected but key absent — record and fail.
+      missingKeys.push(key);
+      continue;
+    }
+    if (isMatcherSpec(value)) {
+      if (actualValue === undefined) {
+        missingKeys.push(key);
+        continue;
+      }
+      if (!matchesScalar(value, actualValue)) {
+        return { matched: false, missingKeys };
+      }
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const sub = matchParams(value, actualValue);
+      missingKeys.push(...sub.missingKeys.map((k) => `${key}.${k}`));
+      if (!sub.matched) {
+        return { matched: false, missingKeys };
+      }
+      continue;
+    }
+    if (Array.isArray(value)) {
+      if (!Array.isArray(actualValue)) {
+        return { matched: false, missingKeys };
+      }
+      const allFound = value.every((needle) =>
+        actualValue.some((item) => matchesScalar(needle, item) || isSubsetValue(needle, item))
+      );
+      if (!allFound) {
+        return { matched: false, missingKeys };
+      }
+      continue;
+    }
+    if (value !== actualValue) {
+      return { matched: false, missingKeys };
+    }
+  }
+  if (missingKeys.length > 0) {
+    return { matched: false, missingKeys };
+  }
+  return { matched: true, missingKeys: [] };
+}
+
+/**
+ * Apply a single matcher spec across ANY string field in a tool input.
+ * Used for rules like "deny anything mentioning ~/.ssh" where the user
+ * doesn't know which parameter key the tool uses.
+ */
+export function matchesAnyStringField(spec, toolInput, depth = 0) {
+  if (depth > 4) return false;
+  if (toolInput === null || toolInput === undefined) return false;
+  if (typeof toolInput === "string") {
+    return matchesScalar(spec, toolInput);
+  }
+  if (Array.isArray(toolInput)) {
+    return toolInput.some((entry) => matchesAnyStringField(spec, entry, depth + 1));
+  }
+  if (isPlainObject(toolInput)) {
+    for (const value of Object.values(toolInput)) {
+      if (matchesAnyStringField(spec, value, depth + 1)) return true;
+    }
+  }
+  return false;
+}
+
 function sanitizeValue(value, limits, depth) {
   if (depth > limits.maxDepth) {
     return "<max-depth>";

--- a/scripts/lib/policy.mjs
+++ b/scripts/lib/policy.mjs
@@ -1,5 +1,13 @@
 import { createHash } from "node:crypto";
-import { isPlainObject, isSubsetValue, normalizeToolName } from "./common.mjs";
+import {
+  isMatcherSpec,
+  isPlainObject,
+  isSubsetValue,
+  matchParams,
+  matchesAnyStringField,
+  matchesScalar,
+  normalizeToolName
+} from "./common.mjs";
 import { readJson, writeJson } from "./fs-store.mjs";
 
 const POLICY_ACTIONS = new Set(["allow", "deny", "require_approval"]);
@@ -25,6 +33,15 @@ function normalizeRule(rule) {
   }
   if (isPlainObject(rule.params)) {
     normalized.params = rule.params;
+  }
+  // anyParam: matcher applied across any string field in the tool input.
+  // Useful for free-text intents like "deny ~/.ssh" where we don't know
+  // which key the tool will store the path under.
+  if (isMatcherSpec(rule.anyParam) || typeof rule.anyParam === "string") {
+    normalized.anyParam =
+      typeof rule.anyParam === "string"
+        ? { $contains: rule.anyParam }
+        : rule.anyParam;
   }
   return normalized;
 }
@@ -153,6 +170,7 @@ export function detectDataClasses(toolName, toolParams) {
 export function evaluatePolicy({ policy, toolName, toolParams }) {
   const rules = normalizePolicy(policy).rules;
   const dataClasses = detectDataClasses(toolName, toolParams);
+  const warnings = [];
 
   for (const rule of rules) {
     if (!toolMatches(rule.tool, toolName)) {
@@ -161,18 +179,42 @@ export function evaluatePolicy({ policy, toolName, toolParams }) {
     if (rule.dataClass && !dataClasses.has(rule.dataClass)) {
       continue;
     }
-    if (rule.params && !isSubsetValue(rule.params, toolParams || {})) {
+    let paramsMatched = true;
+    if (rule.params) {
+      const result = matchParams(rule.params, toolParams || {});
+      paramsMatched = result.matched;
+      // Surface "rule probably won't fire" — the rule references keys that
+      // don't exist on this tool's input, which usually means the user's
+      // intent isn't expressible as-is.
+      if (!result.matched && result.missingKeys.length > 0) {
+        warnings.push({
+          ruleId: rule.id,
+          tool: rule.tool,
+          missingKeys: result.missingKeys,
+          message: `Rule ${rule.id} references keys absent from ${toolName} input: ${result.missingKeys.join(", ")}. Consider using anyParam or operator-based matchers.`
+        });
+      }
+    }
+    if (!paramsMatched) {
       continue;
     }
+    // anyParam matches if ANY string field in the tool input satisfies the
+    // matcher. Useful when the user doesn't know which key holds the path.
+    if (rule.anyParam) {
+      if (!matchesAnyStringField(rule.anyParam, toolParams || {})) {
+        continue;
+      }
+    }
     if (rule.action === "allow") {
-      return { allowed: true, matchedRule: rule, dataClasses: Array.from(dataClasses) };
+      return { allowed: true, matchedRule: rule, dataClasses: Array.from(dataClasses), warnings };
     }
     if (rule.action === "deny") {
       return {
         allowed: false,
         reason: `ArmorClaude policy deny: ${rule.id}`,
         matchedRule: rule,
-        dataClasses: Array.from(dataClasses)
+        dataClasses: Array.from(dataClasses),
+        warnings
       };
     }
     if (rule.action === "require_approval") {
@@ -180,12 +222,13 @@ export function evaluatePolicy({ policy, toolName, toolParams }) {
         allowed: false,
         reason: `ArmorClaude policy requires approval: ${rule.id}`,
         matchedRule: rule,
-        dataClasses: Array.from(dataClasses)
+        dataClasses: Array.from(dataClasses),
+        warnings
       };
     }
   }
 
-  return { allowed: true, dataClasses: Array.from(dataClasses) };
+  return { allowed: true, dataClasses: Array.from(dataClasses), warnings };
 }
 
 function truncateReason(text, max = 160) {
@@ -200,6 +243,14 @@ function formatRule(rule) {
   const parts = [`id=${rule.id}`, `action=${rule.action}`, `tool=${rule.tool}`];
   if (rule.dataClass) {
     parts.push(`dataClass=${rule.dataClass}`);
+  }
+  if (rule.anyParam) {
+    const op = Object.keys(rule.anyParam)[0];
+    const val = rule.anyParam[op];
+    parts.push(`match=${op}:${val}`);
+  }
+  if (rule.params) {
+    parts.push(`params=${JSON.stringify(rule.params)}`);
   }
   return parts.join(" ");
 }
@@ -282,21 +333,82 @@ function inferPolicyTool(text) {
   return "*";
 }
 
+// Detect a path or substring the user wants to block. Looks for things like
+// ~/.ssh, /etc/passwd, or quoted/backticked snippets after "block"/"deny".
+function inferAnyParamMatcher(text) {
+  // Quoted snippets first — most explicit.
+  const quoted =
+    text.match(/"([^"\n]{2,80})"/) ||
+    text.match(/'([^'\n]{2,80})'/);
+  if (quoted && quoted[1]) {
+    return inferMatcherForPhrase(quoted[1]);
+  }
+  // Path-like tokens: ~/..., /xxx/yyy, $HOME/...
+  const pathMatch = text.match(/((?:~|\$\{?HOME\}?|\/)[\w./@\-+~]{2,120})/);
+  if (pathMatch && pathMatch[1]) {
+    const candidate = pathMatch[1].replace(/[.,;:)\]}]+$/, "");
+    if (candidate.length >= 2) {
+      return { $pathContains: candidate };
+    }
+  }
+  return null;
+}
+
+function inferMatcherForPhrase(phrase) {
+  const trimmed = phrase.trim();
+  if (!trimmed) return null;
+  if (/^(?:~|\$\{?HOME\}?|\/)/.test(trimmed)) {
+    return { $pathContains: trimmed };
+  }
+  // Looks like a regex — leave operator-based match.
+  if (/[\\^$+?(){}[\]|]/.test(trimmed)) {
+    return { $matches: trimmed };
+  }
+  return { $contains: trimmed };
+}
+
+// Real Claude Code tools we recognize. Used to disambiguate "block X for Y"
+// where X may or may not be a tool name. Falls back to "*" when X isn't here.
+const KNOWN_CLAUDE_TOOLS = new Set([
+  "*",
+  "read", "write", "edit", "bash", "glob", "grep",
+  "webfetch", "websearch", "agent", "task", "todowrite",
+  "notebookedit", "askuserquestion", "exitplanmode", "skill",
+  "register_intent_plan", "policy_read", "policy_update"
+]);
+
 function buildPolicyUpdateFromText(text, state, forceNewId = false) {
   const explicitIdMatch = text.match(/\bpolicy[-_]?(\d+)\b/i);
   const explicitId = explicitIdMatch && explicitIdMatch[1] ? `policy${explicitIdMatch[1]}` : "";
   const id = forceNewId ? nextPolicyId(state) : explicitId || nextPolicyId(state);
+  const inferredTool = inferPolicyTool(text);
+  const anyParam = inferAnyParamMatcher(text);
+
+  // If we found a path/phrase to match AND the inferred tool is a verb like
+  // "access" or any unknown name, the user means "block this content across
+  // all tools" — promote tool to "*". A real tool name (Bash, Read, Glob...)
+  // stays as-is so users can scope rules to a specific tool when they want.
+  let tool = inferredTool;
+  if (anyParam && tool !== "*") {
+    const normalized = tool.toLowerCase();
+    if (!KNOWN_CLAUDE_TOOLS.has(normalized)) {
+      tool = "*";
+    }
+  }
+
+  const rule = {
+    id,
+    action: inferPolicyAction(text),
+    tool,
+    dataClass: inferPolicyDataClass(text)
+  };
+  if (anyParam) {
+    rule.anyParam = anyParam;
+  }
   return {
     reason: truncateReason(`User policy update: ${text}`),
     mode: /replace/i.test(text) ? "replace" : "merge",
-    rules: [
-      {
-        id,
-        action: inferPolicyAction(text),
-        tool: inferPolicyTool(text),
-        dataClass: inferPolicyDataClass(text)
-      }
-    ]
+    rules: [rule]
   };
 }
 

--- a/tests/matcher.test.mjs
+++ b/tests/matcher.test.mjs
@@ -1,0 +1,315 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isMatcherSpec,
+  matchesScalar,
+  matchParams,
+  matchesAnyStringField
+} from "../scripts/lib/common.mjs";
+import { evaluatePolicy, parsePolicyTextCommand } from "../scripts/lib/policy.mjs";
+
+// ---------------------------------------------------------------------------
+// matchesScalar — operator coverage
+// ---------------------------------------------------------------------------
+
+test("matchesScalar plain literal exact", () => {
+  assert.equal(matchesScalar("ls /etc", "ls /etc"), true);
+  assert.equal(matchesScalar("ls /etc", "ls /tmp"), false);
+});
+
+test("matchesScalar $contains case-insensitive", () => {
+  assert.equal(matchesScalar({ $contains: ".SSH" }, "ls ~/.ssh"), true);
+  assert.equal(matchesScalar({ $contains: ".ssh" }, "ls /tmp"), false);
+});
+
+test("matchesScalar $startsWith / $endsWith", () => {
+  assert.equal(matchesScalar({ $startsWith: "rm " }, "rm -rf /"), true);
+  assert.equal(matchesScalar({ $startsWith: "rm " }, "ls"), false);
+  assert.equal(matchesScalar({ $endsWith: ".pem" }, "/keys/id_rsa.pem"), true);
+  assert.equal(matchesScalar({ $endsWith: ".pem" }, "/keys/id_rsa"), false);
+});
+
+test("matchesScalar $matches regex", () => {
+  assert.equal(matchesScalar({ $matches: "id_(rsa|ed25519)" }, "/.ssh/id_ed25519"), true);
+  assert.equal(matchesScalar({ $matches: "id_(rsa|ed25519)" }, "/.ssh/known_hosts"), false);
+});
+
+test("matchesScalar $pathContains canonicalizes ~/ and $HOME", () => {
+  // Rule mentions ~/.ssh, actual path is /Users/foo/.ssh
+  assert.equal(
+    matchesScalar({ $pathContains: "~/.ssh" }, "/Users/alice/.ssh/id_rsa"),
+    true
+  );
+  // /home/<user> form too
+  assert.equal(
+    matchesScalar({ $pathContains: "~/.ssh" }, "/home/bob/.ssh/known_hosts"),
+    true
+  );
+  // Doesn't match unrelated path
+  assert.equal(
+    matchesScalar({ $pathContains: "~/.ssh" }, "/etc/hosts"),
+    false
+  );
+});
+
+test("matchesScalar $pathContains with $HOME prefix", () => {
+  assert.equal(
+    matchesScalar({ $pathContains: "$HOME/.aws" }, "/Users/alice/.aws/credentials"),
+    true
+  );
+});
+
+test("isMatcherSpec recognizes operator objects", () => {
+  assert.equal(isMatcherSpec({ $contains: "x" }), true);
+  assert.equal(isMatcherSpec({ command: "x" }), false);
+  assert.equal(isMatcherSpec("plain string"), false);
+  assert.equal(isMatcherSpec(null), false);
+  assert.equal(isMatcherSpec({}), false);
+});
+
+// ---------------------------------------------------------------------------
+// matchParams — recursive, surfaces missingKeys
+// ---------------------------------------------------------------------------
+
+test("matchParams plain literal exact (back-compat)", () => {
+  const result = matchParams({ command: "ls" }, { command: "ls" });
+  assert.equal(result.matched, true);
+});
+
+test("matchParams operator on nested key", () => {
+  const result = matchParams(
+    { command: { $contains: ".ssh" } },
+    { command: "ls -la ~/.ssh" }
+  );
+  assert.equal(result.matched, true);
+});
+
+test("matchParams reports missing keys (rule key not in tool input)", () => {
+  const result = matchParams(
+    { pathContains: "/.ssh" },
+    { command: "ls" } // no pathContains key
+  );
+  assert.equal(result.matched, false);
+  assert.deepEqual(result.missingKeys, ["pathContains"]);
+});
+
+test("matchParams missing keys for operator-spec values too", () => {
+  const result = matchParams(
+    { file_path: { $contains: ".pem" } },
+    { command: "ls" }
+  );
+  assert.equal(result.matched, false);
+  assert.deepEqual(result.missingKeys, ["file_path"]);
+});
+
+// ---------------------------------------------------------------------------
+// matchesAnyStringField — wildcard scan over input
+// ---------------------------------------------------------------------------
+
+test("matchesAnyStringField finds .ssh inside any value", () => {
+  assert.equal(
+    matchesAnyStringField({ $contains: ".ssh" }, { command: "ls ~/.ssh/id_rsa" }),
+    true
+  );
+  assert.equal(
+    matchesAnyStringField({ $contains: ".ssh" }, { pattern: "**/.ssh/**", path: "/home/u" }),
+    true
+  );
+  assert.equal(
+    matchesAnyStringField({ $contains: ".ssh" }, { command: "ls /etc" }),
+    false
+  );
+});
+
+test("matchesAnyStringField with $pathContains canonicalizes", () => {
+  assert.equal(
+    matchesAnyStringField(
+      { $pathContains: "~/.ssh" },
+      { file_path: "/Users/alice/.ssh/authorized_keys" }
+    ),
+    true
+  );
+});
+
+// ---------------------------------------------------------------------------
+// evaluatePolicy — end-to-end with operator-based rules
+// ---------------------------------------------------------------------------
+
+test("evaluatePolicy denies via $contains on Bash command", () => {
+  const decision = evaluatePolicy({
+    policy: {
+      rules: [
+        {
+          id: "ssh-block",
+          action: "deny",
+          tool: "Bash",
+          params: { command: { $contains: ".ssh" } }
+        }
+      ]
+    },
+    toolName: "Bash",
+    toolParams: { command: "ls -la ~/.ssh" }
+  });
+  assert.equal(decision.allowed, false);
+  assert.match(decision.reason, /policy deny: ssh-block/);
+});
+
+test("evaluatePolicy denies via anyParam (path canonicalization)", () => {
+  const decision = evaluatePolicy({
+    policy: {
+      rules: [
+        {
+          id: "ssh-everywhere",
+          action: "deny",
+          tool: "*",
+          anyParam: { $pathContains: "~/.ssh" }
+        }
+      ]
+    },
+    toolName: "Glob",
+    toolParams: { pattern: "**/id_*", path: "/home/alice/.ssh" }
+  });
+  assert.equal(decision.allowed, false);
+  assert.match(decision.reason, /ssh-everywhere/);
+});
+
+test("evaluatePolicy denies macOS path even when rule says ~/.ssh", () => {
+  const decision = evaluatePolicy({
+    policy: {
+      rules: [
+        {
+          id: "ssh-anywhere",
+          action: "deny",
+          tool: "*",
+          anyParam: { $pathContains: "~/.ssh" }
+        }
+      ]
+    },
+    toolName: "Read",
+    toolParams: { file_path: "/Users/bob/.ssh/id_ed25519" }
+  });
+  assert.equal(decision.allowed, false);
+});
+
+test("evaluatePolicy surfaces missingKeys warning when rule references absent key", () => {
+  const decision = evaluatePolicy({
+    policy: {
+      rules: [
+        {
+          id: "wrong-shape",
+          action: "deny",
+          tool: "Bash",
+          params: { pathContains: { $contains: ".ssh" } }
+        }
+      ]
+    },
+    toolName: "Bash",
+    toolParams: { command: "ls ~/.ssh" }
+  });
+  assert.equal(decision.allowed, true); // rule didn't fire — Bash has no pathContains key
+  assert.ok(Array.isArray(decision.warnings));
+  assert.ok(
+    decision.warnings.some((w) => w.ruleId === "wrong-shape" && w.missingKeys.includes("pathContains")),
+    "should surface missingKeys warning for wrong-shape rule"
+  );
+});
+
+test("evaluatePolicy still passes back-compat exact-match rules", () => {
+  const decision = evaluatePolicy({
+    policy: {
+      rules: [{ id: "exact", action: "deny", tool: "Bash", params: { command: "ls /etc" } }]
+    },
+    toolName: "Bash",
+    toolParams: { command: "ls /etc" }
+  });
+  assert.equal(decision.allowed, false);
+  assert.match(decision.reason, /exact/);
+});
+
+// ---------------------------------------------------------------------------
+// parsePolicyTextCommand — auto-attach anyParam matcher for path intents
+// ---------------------------------------------------------------------------
+
+test("parsePolicyTextCommand attaches anyParam for ~/.ssh intent", () => {
+  const cmd = parsePolicyTextCommand("Policy new: deny access to ~/.ssh", {
+    version: 0,
+    policy: { rules: [] }
+  });
+  assert.equal(cmd.kind, "update");
+  const rule = cmd.update.rules[0];
+  assert.equal(rule.action, "deny");
+  assert.ok(rule.anyParam, "should have anyParam matcher");
+  assert.equal(rule.anyParam.$pathContains, "~/.ssh");
+});
+
+test("parsePolicyTextCommand attaches anyParam for absolute path intent", () => {
+  const cmd = parsePolicyTextCommand("Policy new: block /etc/passwd", {
+    version: 0,
+    policy: { rules: [] }
+  });
+  const rule = cmd.update.rules[0];
+  assert.equal(rule.anyParam.$pathContains, "/etc/passwd");
+});
+
+test("parsePolicyTextCommand attaches $contains for quoted phrase", () => {
+  const cmd = parsePolicyTextCommand('Policy new: deny "AWS_SECRET_ACCESS_KEY"', {
+    version: 0,
+    policy: { rules: [] }
+  });
+  const rule = cmd.update.rules[0];
+  assert.equal(rule.anyParam.$contains, "AWS_SECRET_ACCESS_KEY");
+});
+
+test("parsePolicyTextCommand still works for plain tool deny (no anyParam)", () => {
+  const cmd = parsePolicyTextCommand("Policy new: deny WebFetch", {
+    version: 0,
+    policy: { rules: [] }
+  });
+  const rule = cmd.update.rules[0];
+  assert.equal(rule.tool, "WebFetch");
+  assert.equal(rule.anyParam, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: text command → rule → blocks the actual tool call
+// ---------------------------------------------------------------------------
+
+test("E2E: 'block ~/.ssh' rule actually blocks Bash AND Glob AND Read", () => {
+  const cmd = parsePolicyTextCommand("Policy new: block ~/.ssh", {
+    version: 0,
+    policy: { rules: [] }
+  });
+  const rules = cmd.update.rules;
+
+  // Bash with command that touches ~/.ssh
+  const bashDecision = evaluatePolicy({
+    policy: { rules },
+    toolName: "Bash",
+    toolParams: { command: "cat ~/.ssh/id_rsa" }
+  });
+  assert.equal(bashDecision.allowed, false, "Bash should be blocked");
+
+  // Glob targeting the .ssh directory
+  const globDecision = evaluatePolicy({
+    policy: { rules },
+    toolName: "Glob",
+    toolParams: { pattern: "id_*", path: "/Users/alice/.ssh" }
+  });
+  assert.equal(globDecision.allowed, false, "Glob should be blocked");
+
+  // Read on a file inside .ssh
+  const readDecision = evaluatePolicy({
+    policy: { rules },
+    toolName: "Read",
+    toolParams: { file_path: "/home/bob/.ssh/authorized_keys" }
+  });
+  assert.equal(readDecision.allowed, false, "Read should be blocked");
+
+  // Unrelated tool call should NOT be blocked
+  const okDecision = evaluatePolicy({
+    policy: { rules },
+    toolName: "Read",
+    toolParams: { file_path: "/tmp/notes.txt" }
+  });
+  assert.equal(okDecision.allowed, true, "Unrelated Read should pass");
+});


### PR DESCRIPTION
## Summary
- Installer passes `--product armorclaude` to `armoriq login` so the device-approval page can brand correctly
- Operator-based policy matchers (`anyParam`, `\$contains`, `\$pathContains`, `\$startsWith`, `\$endsWith`, `\$matches`) with path canonicalization
- New matcher tests (`tests/matcher.test.mjs`)

Companion PRs in this product-aware device flow series:
- conmap-auto: backend accepts optional `product` field on `/auth/device/code`
- armorIQ-Frontend: device-approval page shows product-aware heading + tagline
- armoriq-sdk-customer: CLI `--product` flag plumbed through `login`
- armorCodex: same flow, mirrored on the Codex side (#2)

## Test plan
- [x] `npm test` (matcher suite + existing tests)
- [ ] Run `bash install_armorclaude.sh` and confirm device-approval page shows ArmorClaude branding
- [ ] Verify policy NL commands (`block ~/.ssh`, `deny Bash containing curl`) parse and enforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)