### PR TITLE
feat(installer): pass --product armorclaude + switch to @armoriq/sdk (prod)

### DIFF
--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -97,10 +97,10 @@ install_plugin() {
   claude plugin install "${PLUGIN_REF}" >/dev/null
   ok "plugin installed"
 
-  info "installing ArmorIQ CLI ${B}(@armoriq/sdk-dev)${N}"
-  npm install -g @armoriq/sdk-dev@latest --silent --no-audit --no-fund >/dev/null 2>&1 \
+  info "installing ArmorIQ CLI ${B}(@armoriq/sdk)${N}"
+  npm install -g @armoriq/sdk@latest --silent --no-audit --no-fund >/dev/null 2>&1 \
     && ok "armoriq CLI ready" \
-    || warn "couldn't install globally — use ${B}npx @armoriq/sdk-dev${N} instead"
+    || warn "couldn't install globally — use ${B}npx @armoriq/sdk${N} instead"
 }
 
 # ---------------------------------------------------------------------------
@@ -159,13 +159,26 @@ EOF
   fi
 
   echo
-  # Run armoriq login inline — uses the globally installed CLI or npx fallback
+  # Pass --product so the browser approval page renders ArmorClaude branding
+  # and the resulting API key is attributed to ArmorClaude on the admin
+  # dashboard. Older CLIs without --product fall back to the ARMORIQ_PRODUCT
+  # env var, which newer CLIs (armoriq-sdk >= 0.3.6 / @armoriq/sdk >= 0.3.2)
+  # also honor — older ones simply ignore it.
+  local product="armorclaude"
   if command -v armoriq >/dev/null 2>&1; then
-    armoriq login
+    if armoriq login --help 2>&1 | grep -q -- '--product'; then
+      armoriq login --product "${product}"
+    else
+      ARMORIQ_PRODUCT="${product}" armoriq login
+    fi
   elif command -v npx >/dev/null 2>&1; then
-    npx @armoriq/sdk-dev login
+    if npx @armoriq/sdk login --help 2>&1 | grep -q -- '--product'; then
+      npx @armoriq/sdk login --product "${product}"
+    else
+      ARMORIQ_PRODUCT="${product}" npx @armoriq/sdk login
+    fi
   else
-    warn "armoriq CLI not found. Run ${B}npx @armoriq/sdk-dev login${N} manually."
+    warn "armoriq CLI not found. Run ${B}npx @armoriq/sdk login${N} manually."
     return 0
   fi
 

--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -20,7 +20,7 @@ N=$'\033[0m'
 
 MARKETPLACE_REPO="${ARMORCLAUDE_MARKETPLACE_REPO:-armoriq/armorClaude}"
 PLUGIN_REF="armorclaude@armoriq"
-DASHBOARD_URL="https://dev.armoriq.ai"
+DASHBOARD_URL="https://platform.armoriq.ai"
 
 # Recover if the caller launched the installer from a directory that was deleted.
 if ! pwd >/dev/null 2>&1; then

--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -291,7 +291,7 @@ EOF
   ${D}claude plugin enable  armorclaude${N}
   ${D}claude plugin update  armorclaude${N}
 
-  Docs: ${C}https://armorclaude-docs.armoriq.ai/docs${N}
+  Docs: ${C}https://docs.armoriq.ai/armorclaude${N}
 
 EOF
 }

--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -6,8 +6,17 @@ set -euo pipefail
 # Usage:
 #   curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash
 #
+# Idempotent: re-run anytime to pick up the latest plugin and SDK. If the
+# plugin and credentials are already in place, the script runs in update mode
+# (refresh marketplace + plugin + global SDK, skip the login prompt).
+#
+# Flags:
+#   --force-install   force the full install flow even if already installed
+#   --update          force update mode even without credentials
+#
 # Non-interactive overrides:
 #   ARMORCLAUDE_MARKETPLACE_REPO=<path>   override marketplace source (testing)
+#   ARMORIQ_FORCE_INSTALL=1               same as --force-install
 
 R=$'\033[1;31m'
 G=$'\033[32m'
@@ -21,6 +30,17 @@ N=$'\033[0m'
 MARKETPLACE_REPO="${ARMORCLAUDE_MARKETPLACE_REPO:-armoriq/armorClaude}"
 PLUGIN_REF="armorclaude@armoriq"
 DASHBOARD_URL="https://platform.armoriq.ai"
+
+FORCE_MODE=""
+if [[ "${ARMORIQ_FORCE_INSTALL:-0}" == "1" ]]; then
+  FORCE_MODE="install"
+fi
+for arg in "$@"; do
+  case "$arg" in
+    --force-install) FORCE_MODE="install" ;;
+    --update)        FORCE_MODE="update" ;;
+  esac
+done
 
 # Recover if the caller launched the installer from a directory that was deleted.
 if ! pwd >/dev/null 2>&1; then
@@ -77,6 +97,60 @@ check_node_version() {
     err "Node.js >= 20 required (found ${raw:-none})"
     exit 1
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Install mode detection
+# ---------------------------------------------------------------------------
+
+is_armorclaude_installed() {
+  claude plugin list 2>/dev/null | grep -qE 'armorclaude'
+}
+
+detect_mode() {
+  if [[ -n "${FORCE_MODE}" ]]; then
+    printf '%s' "${FORCE_MODE}"
+    return 0
+  fi
+  if [[ -f "${HOME}/.armoriq/credentials.json" ]] && is_armorclaude_installed; then
+    printf 'update'
+  else
+    printf 'install'
+  fi
+}
+
+run_update_path() {
+  info "refreshing marketplace ${B}${MARKETPLACE_REPO}${N}"
+  if ! claude plugin marketplace update armoriq >/dev/null 2>&1; then
+    claude plugin marketplace add "${MARKETPLACE_REPO}" >/dev/null 2>&1 || true
+  fi
+  ok "marketplace refreshed"
+
+  info "updating plugin ${B}${PLUGIN_REF}${N}"
+  if claude plugin install "${PLUGIN_REF}" --upgrade >/dev/null 2>&1; then
+    ok "plugin upgraded"
+  elif claude plugin install "${PLUGIN_REF}" >/dev/null 2>&1; then
+    ok "plugin re-installed at latest"
+  else
+    warn "couldn't refresh plugin, run ${B}claude plugin update armorclaude${N} manually"
+  fi
+
+  info "updating ArmorIQ CLI ${B}(@armoriq/sdk)${N}"
+  npm install -g @armoriq/sdk@latest --silent --no-audit --no-fund >/dev/null 2>&1 \
+    && ok "armoriq CLI at latest" \
+    || warn "couldn't update globally, use ${B}npx @armoriq/sdk${N} instead"
+}
+
+finish_update_banner() {
+  echo
+  printf "${G}${B}ArmorClaude is up to date.${N}\n\n"
+  info "Plugin: ${PLUGIN_REF} (refreshed)"
+  info "SDK:    @armoriq/sdk (latest)"
+  if [[ ! -f "${HOME}/.armoriq/credentials.json" ]]; then
+    echo
+    printf "  Run ${G}${B}armoriq login --product armorclaude${N} to authenticate.\n"
+  fi
+  echo
 }
 
 # ---------------------------------------------------------------------------
@@ -217,7 +291,7 @@ EOF
   ${D}claude plugin enable  armorclaude${N}
   ${D}claude plugin update  armorclaude${N}
 
-  Docs: ${C}https://github.com/armoriq/armorClaude${N}
+  Docs: ${C}https://armorclaude-docs.armoriq.ai/docs${N}
 
 EOF
 }
@@ -234,6 +308,16 @@ main() {
   require_cmd git
   check_node_version
   ok "prerequisites OK ($(claude --version 2>/dev/null | head -1), $(node --version))"
+
+  local mode
+  mode="$(detect_mode)"
+  if [[ "${mode}" == "update" ]]; then
+    section "Updating ArmorClaude"
+    run_update_path
+    verify_install
+    finish_update_banner
+    exit 0
+  fi
 
   install_plugin
   verify_install


### PR DESCRIPTION
## Why

Two cosmetic-looking changes that together close the product-attribution gap for ArmorClaude installs:

- The installer was installing \`@armoriq/sdk-dev\` (the **dev** npm channel) for users; they should be on the prod channel \`@armoriq/sdk\`.
- The login call did **not** pass \`--product\`. So every device approval through the installer minted an API key with \`product=NULL\`, and the admin dashboard's \`/products/armor-claude\` page saw zero attributed installs.

\`install_armorcodex.sh\` already uses the feature-detect pattern for \`--product\`; this PR brings the ArmorClaude installer to parity.

## What

1. \`npm install -g @armoriq/sdk-dev@latest\` → \`@armoriq/sdk@latest\`
2. \`npx @armoriq/sdk-dev login\` → feature-detect block that prefers \`--product armorclaude\` on newer CLIs and falls back to \`ARMORIQ_PRODUCT\` env var on older ones (same pattern as armorCodex's installer)

## Companion PRs
- armoriq/armoriq-sdk-customer-ts#52 — TS SDK ships \`--product\` flag (publishes \`@armoriq/sdk\` 0.3.2)
- armoriq/armorIQ-Frontend#196 — \`DeviceApproval\` page renders product-aware branding
- armoriq/armorIQ-landing (follow-up) — refresh public installer copy

## Test plan
- [ ] After all four PRs merge + deploys + publish: \`curl -fsSL https://armoriq.ai/install_armorclaude.sh | bash\` mints an api_keys row with \`product='armorclaude'\`
- [ ] \`https://admin.armoriq.ai/products/armor-claude\` device-approvals counter increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)