### PR TITLE
fix(config): point backendEndpoint at prod api.armoriq.ai (not staging)

### DIFF
--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -40,7 +40,7 @@ export function loadConfig(env = process.env) {
     env.ARMORCLAUDE_BACKEND_ENDPOINT?.trim() ||
     env.BACKEND_ENDPOINT?.trim() ||
     (useProduction
-      ? "https://staging-api.armoriq.ai"
+      ? "https://api.armoriq.ai"
       : "http://127.0.0.1:3000");
 
   const iapEndpoint =


### PR DESCRIPTION
## Summary

The production fallback for `backendEndpoint` in [`scripts/lib/config.mjs:43`](scripts/lib/config.mjs#L43) was hardcoded to `https://staging-api.armoriq.ai`. The same file's `iapEndpoint` and `proxyEndpoint` correctly use prod hostnames — only `backendEndpoint` was wrong.

## Impact

In `useProduction` mode (the default for end users):
1. The IAP service in `scripts/lib/iap-service.mjs` posts to `${backendEndpoint}/iap/verify-step` and `${backendEndpoint}/iap/audit`
2. Those URLs resolve to `staging-api.armoriq.ai`
3. User's `ak_live_*` prod API key is unknown to staging → backend returns `Invalid or expired API key`
4. Per-tool verify-step and audit calls silently no-op, so the prod admin dashboard at `platform.armoriq.ai/products/armor-claude` never sees any data even after a successful install + login

Same root cause as armoriq/armorCodex#13.

## Fix

One-line change to point at `api.armoriq.ai` in production. Staging users are unaffected (different branch in the resolution chain).

## Workaround for already-installed users

Until this fix lands and the plugin is republished + updated, set the plugin userConfig `api_key` field via Claude Code's plugin settings, OR export:

```bash
export ARMORCLAUDE_BACKEND_ENDPOINT=https://api.armoriq.ai
```

before launching Claude Code.

## Test plan

- [ ] After publishing, `claude plugin update armorclaude` pulls the fix
- [ ] In a Claude Code session, run any tool → audit row appears on `platform.armoriq.ai/products/armor-claude` Recent activity
- [ ] No "Invalid API key" errors in claude logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)