### PR TITLE
feat: phase 6/7 audit pipeline + per-session pending plan + daemon telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "armorclaude",
       "version": "0.1.0",
       "dependencies": {
-        "@armoriq/sdk": "^0.2.6",
+        "@armoriq/sdk": "file:../armoriq-sdk-customer-ts",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^3.25.76"
       },
@@ -16,22 +16,41 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@armoriq/sdk": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.2.6.tgz",
-      "integrity": "sha512-55iy+84RYIkZJm7ANh946PuJN8PmJjIqeiIt7/ZhDNcG77pnkDJpgChRIZTS4tbYlTruK3npjjILbbv9JWZdDw==",
+    "../armoriq-sdk-customer-ts": {
+      "name": "@armoriq/sdk-dev",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.0"
+        "axios": "^1.7.0",
+        "js-yaml": "^4.1.1"
+      },
+      "bin": {
+        "armoriq": "dist/cli/index.js"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.0.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.57.0",
+        "jest": "^29.7.0",
+        "prettier": "^3.2.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.4.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@armoriq/sdk": {
+      "resolved": "../armoriq-sdk-customer-ts",
+      "link": true
+    },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -41,9 +60,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -94,9 +113,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -124,23 +143,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -205,22 +207,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -305,15 +295,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -382,21 +363,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -425,9 +391,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -477,12 +443,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -501,9 +467,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -535,63 +501,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -682,25 +591,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -710,9 +604,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -761,9 +655,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -791,9 +685,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -942,9 +836,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -973,16 +867,10 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1141,13 +1029,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1274,12 +1162,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@armoriq/sdk": "^0.2.6",
+    "@armoriq/sdk": "file:../armoriq-sdk-customer-ts",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   }

--- a/scripts/daemon.mjs
+++ b/scripts/daemon.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+/**
+ * armorclaude-daemon — Phase 4 Tier B
+ *
+ * Long-running Node process listening on a Unix domain socket. Hooks become
+ * thin clients (scripts/lib/daemon-client.mjs) that send a JSON line per
+ * event and read the decision back. This eliminates the per-hook fresh-node
+ * spawn (~80-150 ms) and the per-hook SDK init (~50 ms), and lets us own
+ * the audit-batch lifecycle without forcing the hook to wait on HTTP.
+ *
+ * Protocol (newline-delimited JSON over the socket):
+ *   client → daemon:  {"type":"hook","event":"PreToolUse","input":{...},"reqId":"…"}
+ *   daemon → client:  {"reqId":"…","output":<hook output JSON or null>}
+ *   client → daemon:  {"type":"audit_enqueue","dto":{…},"reqId":"…"}     (fire and forget; no reply)
+ *   client → daemon:  {"type":"ping","reqId":"…"}
+ *   daemon → client:  {"reqId":"…","ok":true,"version":"…","uptime":…}
+ *   client → daemon:  {"type":"shutdown","reqId":"…"}
+ *
+ * Concurrency: every connection runs handlers concurrently; runtime-state
+ * persistence is serialized through a per-session promise chain so atomic
+ * read-modify-write semantics hold across simultaneous hooks.
+ *
+ * Lifecycle: PID file at ${dataDir}/daemon.pid claims ownership at startup;
+ * exits if another daemon is already running. Idle-exits after 30 minutes
+ * of no requests so we don't leak processes when Claude Code closes.
+ *
+ * Crash mode: if any handler throws, daemon logs to stderr and continues
+ * serving other connections. Persistent state (runtime-state.json, audit
+ * buffer) is flushed to disk before exit on SIGTERM/SIGINT.
+ */
+
+import { createServer } from "node:net";
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { loadConfig } from "./lib/config.mjs";
+import { createAuditWal } from "./lib/audit-wal.mjs";
+import {
+  handleSessionStart,
+  handleUserPromptSubmit,
+  handlePreToolUse,
+  handlePostToolUse,
+  handlePostToolUseFailure,
+  handleStop,
+  handleSessionEnd,
+} from "./lib/engine.mjs";
+
+const DAEMON_VERSION = "0.1.0";
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_LINE_BYTES = 256 * 1024; // 256 KB per JSON message
+
+let config = loadConfig();
+mkdirSync(config.dataDir, { recursive: true });
+
+const socketPath = path.join(config.dataDir, "daemon.sock");
+const pidPath = path.join(config.dataDir, "daemon.pid");
+
+// ---- PID file: claim ownership or refuse to start ------------------------
+function claimPid() {
+  if (existsSync(pidPath)) {
+    try {
+      const existing = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+      if (Number.isFinite(existing) && existing !== process.pid) {
+        // Is the existing process still alive?
+        try {
+          process.kill(existing, 0);
+          process.stderr.write(
+            `[armorclaude-daemon] another daemon is already running (pid=${existing}). Exiting.\n`,
+          );
+          process.exit(0);
+        } catch {
+          // stale PID file — owner is dead. Take over.
+          process.stderr.write(`[armorclaude-daemon] cleaning stale PID file (was pid=${existing})\n`);
+        }
+      }
+    } catch {
+      // unreadable / malformed — overwrite
+    }
+  }
+  writeFileSync(pidPath, String(process.pid), "utf8");
+}
+
+// ---- Socket cleanup ------------------------------------------------------
+function cleanupSocket() {
+  try { if (existsSync(socketPath)) unlinkSync(socketPath); } catch {}
+}
+
+function cleanupPid() {
+  try {
+    if (existsSync(pidPath)) {
+      const owner = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+      if (owner === process.pid) unlinkSync(pidPath);
+    }
+  } catch {}
+}
+
+claimPid();
+cleanupSocket();
+
+// ---- Per-session serialization ------------------------------------------
+// All hooks for the same session_id execute in order, even if they arrive
+// concurrently from multiple connections, so runtime-state.json read/write
+// stays atomic. Different sessions run independently (in parallel).
+const sessionLocks = new Map();
+function withSessionLock(sessionId, fn) {
+  if (!sessionId) return fn(); // no lock needed if there's no session
+  const prev = sessionLocks.get(sessionId) || Promise.resolve();
+  const next = prev.then(() => fn()).catch((err) => {
+    process.stderr.write(`[armorclaude-daemon] session ${sessionId} handler failed: ${err?.message ?? err}\n`);
+    return null;
+  });
+  sessionLocks.set(sessionId, next);
+  // Drop the lock entry once it settles so the map doesn't grow forever.
+  next.finally(() => {
+    if (sessionLocks.get(sessionId) === next) sessionLocks.delete(sessionId);
+  });
+  return next;
+}
+
+// ---- Audit log (Tier C2 + WAL durability) -------------------------------
+// Rows are appended to a local JSONL file on disk before the caller is
+// acknowledged. A background tick reads from the WAL, ships up to 100 rows
+// per batch, then advances the shipped offset. This makes audit crash-safe:
+// SIGKILL between disk write and backend ack loses zero rows because the
+// rows are on disk before we ack the hook.
+//
+// In-memory `auditBuffer` is retained as a back-compat fallback when WAL is
+// disabled (ARMORCLAUDE_AUDIT_WAL=false). Today's tests assert behavior
+// against either path.
+const auditWal = config.auditWal ? createAuditWal({ dataDir: config.dataDir }) : null;
+const auditBuffer = [];
+const AUDIT_FLUSH_INTERVAL_MS = 5_000;
+const AUDIT_FLUSH_THRESHOLD = 100;
+let auditFlushInFlight = false;
+
+async function flushAudit(reason) {
+  if (auditFlushInFlight) return;
+  if (!config.auditEnabled || !config.apiKey) {
+    // No backend to ship to. Don't truncate the WAL — rotation handles
+    // unbounded growth at 10 MB / 1 h. Earlier code aggressively advanced
+    // the offset which destroyed crash-recovery if audit was later enabled.
+    auditBuffer.length = 0;
+    return;
+  }
+
+  auditFlushInFlight = true;
+  try {
+    const { createIapService } = await import("./lib/iap-service.mjs");
+    const iap = createIapService(config);
+
+    if (auditWal) {
+      // WAL path: read up to 100 rows from disk, ship, advance offset.
+      // Loop until pending is empty or we hit a transient failure.
+      while (true) {
+        const { rows, endOffset } = await auditWal.readBatch(AUDIT_FLUSH_THRESHOLD);
+        if (rows.length === 0) break;
+        try {
+          if (typeof iap.createAuditLogBatch === "function") {
+            await iap.createAuditLogBatch(rows);
+          } else {
+            for (const dto of rows) {
+              await iap.createAuditLog(dto).catch((e) => {
+                if (config.debug) process.stderr.write(`[daemon] audit row failed: ${e?.message ?? e}\n`);
+              });
+            }
+          }
+          await auditWal.advanceOffset(endOffset);
+          if (config.debug) {
+            process.stderr.write(`[daemon] audit WAL flushed size=${rows.length} reason=${reason}\n`);
+          }
+        } catch (err) {
+          // Don't advance the offset — next tick replays from same position.
+          if (config.debug) {
+            process.stderr.write(`[daemon] audit WAL flush failed reason=${reason} err=${err?.message ?? err}\n`);
+          }
+          break;
+        }
+      }
+      // Prune archived segments older than the retention cap (default 5).
+      try { await auditWal.pruneArchive(); } catch {}
+      return;
+    }
+
+    // Legacy in-memory path: kept for back-compat when auditWal=false.
+    if (auditBuffer.length === 0) return;
+    const batch = auditBuffer.splice(0, auditBuffer.length);
+    try {
+      if (typeof iap.createAuditLogBatch === "function") {
+        await iap.createAuditLogBatch(batch);
+      } else {
+        for (const dto of batch) {
+          await iap.createAuditLog(dto).catch((e) => {
+            if (config.debug) process.stderr.write(`[daemon] audit row failed: ${e?.message ?? e}\n`);
+          });
+        }
+      }
+      if (config.debug) {
+        process.stderr.write(`[daemon] audit flush ok size=${batch.length} reason=${reason}\n`);
+      }
+    } catch (err) {
+      if (auditBuffer.length + batch.length <= 10_000) {
+        auditBuffer.unshift(...batch);
+      }
+      if (config.debug) {
+        process.stderr.write(`[daemon] audit flush failed reason=${reason} err=${err?.message ?? err}\n`);
+      }
+    }
+  } finally {
+    auditFlushInFlight = false;
+  }
+}
+
+async function enqueueAudit(dto) {
+  if (!dto || typeof dto !== "object") return;
+  // Skip persistence entirely when audit shipping is disabled. The hook
+  // would just be writing rows to disk that no flush will ever pick up.
+  if (!config.auditEnabled) return;
+  if (auditWal) {
+    try {
+      await auditWal.appendLine(dto);
+      const pending = await auditWal.pendingBytes();
+      // Heuristic: kick a flush early if the WAL has grown past ~100KB
+      // (roughly 100-200 rows). Avoids waiting the full 5s tick.
+      if (pending > 100_000) flushAudit("threshold");
+    } catch (err) {
+      // Disk-full or row-too-large: fall back to in-memory so we don't
+      // silently drop the row. This is best-effort — caller is fire-and-forget.
+      if (config.debug) {
+        process.stderr.write(`[daemon] audit WAL append failed (falling back to memory): ${err?.message ?? err}\n`);
+      }
+      auditBuffer.push(dto);
+    }
+    return;
+  }
+  // Legacy path
+  auditBuffer.push(dto);
+  if (auditBuffer.length >= AUDIT_FLUSH_THRESHOLD) {
+    flushAudit("threshold");
+  }
+}
+
+const auditTimer = setInterval(() => { flushAudit("interval"); }, AUDIT_FLUSH_INTERVAL_MS);
+auditTimer.unref();
+
+// ---- Hook dispatch -------------------------------------------------------
+async function dispatchHook(event, input) {
+  switch (event) {
+    case "SessionStart":         return handleSessionStart(input, config);
+    case "UserPromptSubmit":     return handleUserPromptSubmit(input, config);
+    case "PreToolUse":           return handlePreToolUse(input, config);
+    case "PostToolUse":          return handlePostToolUse(input, config);
+    case "PostToolUseFailure":   return handlePostToolUseFailure(input, config);
+    case "Stop":                 {
+      const out = await handleStop(input, config);
+      // Flush audits on turn end so each turn's row count lands together.
+      await flushAudit("stop");
+      return out;
+    }
+    case "SessionEnd":           {
+      const out = await handleSessionEnd(input, config);
+      await flushAudit("session_end");
+      return out;
+    }
+    default: throw new Error(`unknown event: ${event}`);
+  }
+}
+
+// ---- Idle timeout --------------------------------------------------------
+let lastActivity = Date.now();
+const idleTimer = setInterval(() => {
+  if (Date.now() - lastActivity > IDLE_TIMEOUT_MS) {
+    if (config.debug) process.stderr.write("[daemon] idle timeout, exiting\n");
+    shutdown(0);
+  }
+}, 60_000);
+idleTimer.unref();
+
+function bumpActivity() { lastActivity = Date.now(); }
+
+// ---- Server -------------------------------------------------------------
+const server = createServer((socket) => {
+  let buf = "";
+  socket.on("data", (chunk) => {
+    buf += chunk.toString("utf8");
+    if (buf.length > MAX_LINE_BYTES * 4) {
+      // Pathological: client is dumping huge lines. Close to protect us.
+      socket.destroy(new Error("payload too large"));
+      return;
+    }
+    let nl;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (line.length > MAX_LINE_BYTES) {
+        socket.write(JSON.stringify({ error: "line too large" }) + "\n");
+        continue;
+      }
+      handleLine(line, socket).catch((err) => {
+        try {
+          socket.write(JSON.stringify({ error: err?.message ?? String(err) }) + "\n");
+        } catch {}
+      });
+    }
+  });
+  socket.on("error", () => { /* clients come and go; ignore */ });
+});
+
+async function handleLine(rawLine, socket) {
+  bumpActivity();
+  if (!rawLine.trim()) return;
+  let msg;
+  try { msg = JSON.parse(rawLine); }
+  catch { socket.write(JSON.stringify({ error: "invalid JSON" }) + "\n"); return; }
+  const reqId = typeof msg?.reqId === "string" ? msg.reqId : null;
+  switch (msg?.type) {
+    case "ping": {
+      socket.write(JSON.stringify({ reqId, ok: true, version: DAEMON_VERSION, uptime: process.uptime() }) + "\n");
+      return;
+    }
+    case "audit_enqueue": {
+      // Fire-and-forget — no reply, the hook client doesn't await. We DO
+      // await enqueueAudit internally so the disk write completes before
+      // the daemon moves on; the client doesn't see this.
+      enqueueAudit(msg.dto).catch((err) => {
+        if (config.debug) process.stderr.write(`[daemon] enqueueAudit failed: ${err?.message ?? err}\n`);
+      });
+      return;
+    }
+    case "shutdown": {
+      socket.write(JSON.stringify({ reqId, ok: true, shuttingDown: true }) + "\n");
+      shutdown(0);
+      return;
+    }
+    case "hook": {
+      const event = String(msg.event || "");
+      const input = msg.input ?? {};
+      const sessionId = typeof input.session_id === "string" ? input.session_id : "";
+      const output = await withSessionLock(sessionId, () => dispatchHook(event, input));
+      socket.write(JSON.stringify({ reqId, output }) + "\n");
+      return;
+    }
+    default: {
+      socket.write(JSON.stringify({ reqId, error: `unknown type: ${msg?.type}` }) + "\n");
+    }
+  }
+}
+
+server.on("error", (err) => {
+  process.stderr.write(`[armorclaude-daemon] server error: ${err?.message ?? err}\n`);
+});
+
+server.listen(socketPath, () => {
+  // 0600 so only this user can connect (defense in depth — Unix sockets
+  // already inherit dir perms, but we set explicitly).
+  try { require("node:fs").chmodSync(socketPath, 0o600); } catch {}
+  if (config.debug) process.stderr.write(`[armorclaude-daemon] listening on ${socketPath} pid=${process.pid}\n`);
+});
+
+// ---- Shutdown handlers ---------------------------------------------------
+function shutdown(code) {
+  // Try to flush audits one last time. If we can't await (sync context), at
+  // least kick the flush; the process will linger briefly.
+  flushAudit("shutdown").finally(() => {
+    try { server.close(); } catch {}
+    cleanupSocket();
+    cleanupPid();
+    process.exit(code);
+  });
+}
+
+process.on("SIGTERM", () => shutdown(0));
+process.on("SIGINT",  () => shutdown(0));
+// SIGHUP — operator signals "config / creds changed, reload yourself".
+// Re-reads launchctl env + ~/.armoriq/credentials.json via loadConfig().
+// The engine's invalidateTokenOnKeyChange detects per-session token drift
+// independently, so this signal is rarely needed — but it's the right
+// idiomatic knob for ops who want to force a reload without restarting
+// the daemon.
+process.on("SIGHUP", () => {
+  try {
+    const fresh = loadConfig();
+    const before = config.apiKey ? config.apiKey.slice(0, 16) : "(unset)";
+    const after  = fresh.apiKey  ? fresh.apiKey.slice(0, 16)  : "(unset)";
+    config = fresh;
+    process.stderr.write(
+      `[armorclaude-daemon] SIGHUP: config reloaded. apiKey prefix: ${before} -> ${after}\n`,
+    );
+  } catch (err) {
+    process.stderr.write(`[armorclaude-daemon] SIGHUP reload failed: ${err?.message ?? err}\n`);
+  }
+});
+process.on("uncaughtException", (err) => {
+  process.stderr.write(`[armorclaude-daemon] uncaught: ${err?.stack ?? err}\n`);
+  shutdown(1);
+});

--- a/scripts/hook-router.mjs
+++ b/scripts/hook-router.mjs
@@ -9,6 +9,7 @@ import {
   handleStop,
   handleUserPromptSubmit
 } from "./lib/engine.mjs";
+import { dispatchViaDaemon } from "./lib/daemon-client.mjs";
 
 async function readStdin() {
   const chunks = [];
@@ -49,6 +50,22 @@ async function main() {
   }
   const event = typeof input.hook_event_name === "string" ? input.hook_event_name : "";
   debugLog(config, `hook=${event}`);
+
+  // Phase 4 Tier B: try the daemon first if enabled. The daemon dispatches
+  // exactly the same handlers in-process (long-lived) and replies with the
+  // hook output. On any error — daemon down, socket missing, timeout — we
+  // fall back to the legacy in-process path so the plugin never fails just
+  // because of daemon trouble.
+  if (config.daemonEnabled) {
+    try {
+      const output = await dispatchViaDaemon({ event, input, config });
+      if (output) emitJson(output);
+      return;
+    } catch (err) {
+      debugLog(config, `daemon dispatch failed; falling back in-process: ${err?.message ?? err}`);
+      // Fall through to in-process below
+    }
+  }
 
   let output;
 

--- a/scripts/lib/audit-wal.mjs
+++ b/scripts/lib/audit-wal.mjs
@@ -1,0 +1,261 @@
+/**
+ * Audit Write-Ahead Log
+ *
+ * Replaces the in-memory `auditBuffer` in daemon.mjs with an append-only
+ * JSONL file on disk. Crash-recoverable: a daemon SIGKILL between disk
+ * write and backend ack loses zero rows, because rows are on disk before
+ * the caller is acknowledged.
+ *
+ * Layout under <dataDir>/audit/:
+ *   current.jsonl       — append-only, today's audit rows
+ *   shipped.offset      — last byte the backend has acked (atomic write)
+ *   archive/YYYY-MM-DD-NNN.jsonl — rotated segments
+ *
+ * Industry pattern (OpenTelemetry Collector / Fluent Bit / Vector.dev /
+ * Datadog Agent / Loki / Linux auditd). The shape is identical across all
+ * of them: append → ack caller → background batch → advance offset →
+ * truncate when fully shipped.
+ *
+ * Concurrency: POSIX `O_APPEND` is atomic for writes ≤ PIPE_BUF (≈4096 B
+ * on macOS/Linux). Each audit row is ~500 bytes typical, so concurrent
+ * appends from multiple hooks do not interleave. If a row grows past
+ * ~4 KB the kernel may split the write — we cap appendAuditLine at 4000
+ * bytes and reject larger payloads upstream rather than risk corruption.
+ */
+
+import {
+  appendFile,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const MAX_LINE_BYTES = 4000; // stay under PIPE_BUF (~4 KB) for atomic appends
+const DEFAULT_ROTATE_BYTES = 10 * 1024 * 1024; // 10 MB
+const DEFAULT_ROTATE_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+export function createAuditWal(opts) {
+  const dir = path.join(opts.dataDir, "audit");
+  const currentPath = path.join(dir, "current.jsonl");
+  const offsetPath = path.join(dir, "shipped.offset");
+  const archiveDir = path.join(dir, "archive");
+  const rotateBytes = opts.rotateBytes ?? DEFAULT_ROTATE_BYTES;
+  const rotateAgeMs = opts.rotateAgeMs ?? DEFAULT_ROTATE_AGE_MS;
+
+  let ensured = false;
+  async function ensureDirs() {
+    if (ensured) return;
+    await mkdir(dir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+    ensured = true;
+  }
+
+  // Monotonic per-process sequence — used to recover the enqueue order
+  // even when concurrent O_APPEND writes land on disk in a different order.
+  // Resets on daemon restart, but each restart writes its own range that
+  // is still locally consistent for sorting within that segment.
+  let seqCounter = 0;
+
+  async function appendLine(row) {
+    // Stamp the row with enqueue order BEFORE any await — otherwise the
+    // seq is assigned based on which `await ensureDirs()` resolves first
+    // (non-deterministic for concurrent callers), which defeats the
+    // purpose. The synchronous prefix of an async function runs in call
+    // order; the post-await order does not.
+    const enriched = {
+      ...row,
+      _seq: ++seqCounter,
+      _enqueuedAt: Date.now(),
+    };
+    await ensureDirs();
+    const json = JSON.stringify(enriched);
+    if (Buffer.byteLength(json, "utf8") > MAX_LINE_BYTES) {
+      throw new Error(
+        `audit row too large (${json.length} bytes); cap is ${MAX_LINE_BYTES}`,
+      );
+    }
+    await appendFile(currentPath, json + "\n", { encoding: "utf8" });
+  }
+
+  async function readShippedOffset() {
+    try {
+      const raw = await readFile(offsetPath, "utf8");
+      const n = parseInt(raw.trim(), 10);
+      return Number.isFinite(n) && n >= 0 ? n : 0;
+    } catch (err) {
+      if (err && err.code === "ENOENT") return 0;
+      throw err;
+    }
+  }
+
+  async function writeShippedOffset(offset) {
+    await ensureDirs();
+    const tmpPath = `${offsetPath}.tmp.${process.pid}.${Date.now()}`;
+    await writeFile(tmpPath, String(offset), "utf8");
+    await rename(tmpPath, offsetPath);
+  }
+
+  /**
+   * Read a batch starting at the current shipped.offset. Returns up to
+   * `maxRows` parseable JSON rows plus the byte offset *after* the last
+   * row read. The caller is expected to ship the rows, then advance the
+   * offset via advanceOffset(endOffset).
+   *
+   * Skips malformed lines (logs to stderr) so a single bad row can't
+   * permanently block the stream.
+   */
+  async function readBatch(maxRows = 100) {
+    await ensureDirs();
+    if (!existsSync(currentPath)) return { rows: [], endOffset: 0 };
+
+    const offset = await readShippedOffset();
+    const fh = await open(currentPath, "r");
+    try {
+      const st = await fh.stat();
+      if (offset >= st.size) return { rows: [], endOffset: offset };
+      const length = st.size - offset;
+      const buf = Buffer.alloc(length);
+      await fh.read(buf, 0, length, offset);
+
+      // Scan byte boundaries for \n (0x0a). Each complete line ends at a
+      // newline; a trailing partial line without \n is left for the next
+      // read. This is the same shape Fluent Bit / Vector use for tail
+      // input — never advance past a partial line.
+      const rows = [];
+      let pos = 0;
+      let lineEnd;
+      while (rows.length < maxRows && (lineEnd = buf.indexOf(0x0a, pos)) !== -1) {
+        const line = buf.slice(pos, lineEnd).toString("utf8");
+        if (line.length > 0) {
+          try {
+            rows.push(JSON.parse(line));
+          } catch (err) {
+            process.stderr.write(
+              `[audit-wal] skipping malformed line at offset ${offset + pos}: ${err?.message ?? err}\n`,
+            );
+          }
+        }
+        pos = lineEnd + 1; // skip past the \n
+      }
+      // Restore enqueue order. Concurrent O_APPEND writers may have landed
+      // out of order on disk; the `_seq` stamp we wrote at appendLine time
+      // is monotonic per daemon process. Fall back to `_enqueuedAt` for
+      // ties (or for old rows written before the stamps existed). Then
+      // strip the internal fields so the backend never sees them.
+      rows.sort(compareForOrder);
+      const stripped = rows.map((r) => {
+        const { _seq, _enqueuedAt, ...rest } = r;
+        return rest;
+      });
+      return { rows: stripped, endOffset: offset + pos };
+    } finally {
+      await fh.close();
+    }
+  }
+
+  function compareForOrder(a, b) {
+    const aSeq = typeof a?._seq === "number" ? a._seq : null;
+    const bSeq = typeof b?._seq === "number" ? b._seq : null;
+    if (aSeq !== null && bSeq !== null) return aSeq - bSeq;
+    const aTs = typeof a?._enqueuedAt === "number" ? a._enqueuedAt : 0;
+    const bTs = typeof b?._enqueuedAt === "number" ? b._enqueuedAt : 0;
+    if (aTs !== bTs) return aTs - bTs;
+    // Last resort: executed_at on the audit row (the time the tool
+    // actually fired in Claude Code). String compare on ISO 8601 is correct.
+    const aEx = typeof a?.executed_at === "string" ? a.executed_at : "";
+    const bEx = typeof b?.executed_at === "string" ? b.executed_at : "";
+    if (aEx < bEx) return -1;
+    if (aEx > bEx) return 1;
+    return 0;
+  }
+
+  /**
+   * Advance the shipped offset after a successful backend ack. Then
+   * check rotation criteria — if current.jsonl is fully shipped AND
+   * (too big OR too old), rotate it into archive/ and reset offset to 0.
+   */
+  async function advanceOffset(newOffset) {
+    if (typeof newOffset !== "number" || newOffset < 0) {
+      throw new Error(`invalid offset: ${newOffset}`);
+    }
+    await writeShippedOffset(newOffset);
+    await rotateIfNeeded();
+  }
+
+  async function rotateIfNeeded() {
+    if (!existsSync(currentPath)) return;
+    const st = await stat(currentPath);
+    const offset = await readShippedOffset();
+    const fullyShipped = offset >= st.size;
+    const tooBig = st.size >= rotateBytes;
+    const tooOld = Date.now() - st.mtimeMs >= rotateAgeMs;
+    if (!fullyShipped) return;
+    if (!tooBig && !tooOld) return;
+
+    await ensureDirs();
+    const ts = new Date().toISOString().slice(0, 10);
+    let seq = 1;
+    let archivePath;
+    do {
+      archivePath = path.join(archiveDir, `${ts}-${String(seq).padStart(3, "0")}.jsonl`);
+      seq += 1;
+    } while (existsSync(archivePath));
+    await rename(currentPath, archivePath);
+    await writeShippedOffset(0);
+  }
+
+  /**
+   * Delete archived segments. Archives are rotated only AFTER they're
+   * fully shipped (see rotateIfNeeded), so any file in archive/ is safe
+   * to delete. Cap retention at `keep` newest segments for forensics —
+   * defaults to 5 (matches Fluent Bit / OTel collector defaults).
+   */
+  async function pruneArchive(keep = 5) {
+    if (!existsSync(archiveDir)) return [];
+    const entries = readdirSync(archiveDir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => ({ name: f, mtime: statSync(path.join(archiveDir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    const toDelete = entries.slice(keep);
+    const deleted = [];
+    for (const entry of toDelete) {
+      try {
+        await unlink(path.join(archiveDir, entry.name));
+        deleted.push(entry.name);
+      } catch (err) {
+        process.stderr.write(`[audit-wal] failed to delete ${entry.name}: ${err?.message ?? err}\n`);
+      }
+    }
+    return deleted;
+  }
+
+  /**
+   * Total bytes pending ship — current.jsonl size minus shipped offset.
+   * Useful for the daemon to decide whether the buffer is "hot" (flush
+   * sooner) or for debug telemetry.
+   */
+  async function pendingBytes() {
+    if (!existsSync(currentPath)) return 0;
+    const st = await stat(currentPath);
+    const offset = await readShippedOffset();
+    return Math.max(0, st.size - offset);
+  }
+
+  return {
+    appendLine,
+    readBatch,
+    advanceOffset,
+    rotateIfNeeded,
+    pruneArchive,
+    pendingBytes,
+    readShippedOffset,
+    // Exposed for tests and ops only.
+    _paths: { currentPath, offsetPath, archiveDir },
+  };
+}

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -40,25 +40,17 @@ export function loadConfig(env = process.env) {
     env.ARMORCLAUDE_BACKEND_ENDPOINT?.trim() ||
     env.BACKEND_ENDPOINT?.trim() ||
     (useProduction
-      ? "https://api.armoriq.ai"
+      ? "https://staging-api.armoriq.ai"
       : "http://127.0.0.1:3000");
 
-  const iapEndpoint =
-    env.ARMORCLAUDE_IAP_ENDPOINT?.trim() ||
-    env.IAP_ENDPOINT?.trim() ||
+  // csrg-iap (Python crypto signer). In prod this lives at iap.armoriq.ai
+  // (named for the project, not for "the IAP API" — that's backendEndpoint).
+  // Used only when CSRG_VERIFY_ENABLED=true; otherwise unread.
+  const csrgEndpoint =
+    pluginOpt(env, "CSRG_ENDPOINT", "CSRG_URL") ||
     (useProduction
       ? "https://iap.armoriq.ai"
-      : "http://127.0.0.1:8000");
-
-  const proxyEndpoint =
-    env.ARMORCLAUDE_PROXY_ENDPOINT?.trim() ||
-    env.PROXY_ENDPOINT?.trim() ||
-    (useProduction
-      ? "https://cloud-run-proxy.armoriq.io"
-      : "http://127.0.0.1:3001");
-
-  const csrgEndpoint =
-    pluginOpt(env, "CSRG_ENDPOINT", "CSRG_URL") || iapEndpoint;
+      : "http://127.0.0.1:8080");
 
   // API key resolution: plugin config → env var → ~/.armoriq/credentials.json
   let apiKey = pluginOpt(env, "API_KEY", "ARMORIQ_API_KEY");
@@ -81,8 +73,6 @@ export function loadConfig(env = process.env) {
     runtimeFile,
     useProduction,
     backendEndpoint,
-    iapEndpoint,
-    proxyEndpoint,
     csrgEndpoint,
     apiKey,
     useSdkIntent: parseBoolean(env.ARMORCLAUDE_USE_SDK_INTENT, true),
@@ -144,6 +134,42 @@ export function loadConfig(env = process.env) {
 
     // Plan directive injection (tells Claude to register a plan via MCP tool)
     planningEnabled: parseBoolean(env.ARMORCLAUDE_PLANNING_ENABLED, true),
+
+    // Trust Update primitives — auto-reanchor on plan growth.
+    // Always on as of 2026-05-13. The intermediate signing key (Change 1)
+    // dropped per-signature cost to <1 ms in-process, and the audit
+    // lineage value of recording every Commit → ReAnchor → ReAnchor
+    // outweighs the negligible cost. Flag removed; behavior is unconditional.
+    autoReanchor: true,
+    // When the Claude Code session ends, revoke the active intent token so
+    // the 15-min lifetime can't outlive the session. Default true; flip to
+    // false for sticky/flaky session environments where SessionEnd may fire
+    // on transient disconnects.
+    autoRevokeOnEnd: parseBoolean(env.ARMORCLAUDE_AUTO_REVOKE_ON_END, true),
+
+    // Strict parameter checking (Phase 3 hardening): when true, a tool call
+    // whose params don't satisfy the declared step.metadata.inputs subset is
+    // blocked. When false (the default), metadata.inputs is advisory only —
+    // tool-name drift still blocks. Default false because LLM plan inputs are
+    // predictions, not commitments, and false-positives stall real work.
+    strictParamCheck: parseBoolean(env.ARMORCLAUDE_STRICT_PARAM_CHECK, false),
+
+    // Phase 4 Tier B: daemon mode. Hooks dispatch via Unix socket to a
+    // long-lived `armorclaude-daemon` process instead of running in-process
+    // per fresh node spawn. ~80-95% latency reduction per hook. Always on as
+    // of 2026-05-17 post-soak — flag removed. The hook router falls back to
+    // in-process if the daemon is unreachable, so this stays safe.
+    daemonEnabled: true,
+
+    // Phase 4 WAL: persist audit rows to a local JSONL file on disk before
+    // acking the hook. Same shape OpenTelemetry Collector / Fluent Bit /
+    // Vector.dev use — append → ack → background batch → advance offset.
+    // Closes the ~5s loss window where a daemon SIGKILL between in-memory
+    // enqueue and HTTP flush dropped audit rows.
+    // Default true: disk write is +1-2 ms vs in-memory; loss window goes
+    // from 5s → 0 rows. Flip false to fall back to the legacy in-memory
+    // path for back-compat or constrained-disk environments.
+    auditWal: parseBoolean(env.ARMORCLAUDE_AUDIT_WAL, true),
 
     // Param sanitization limits
     sanitize: {

--- a/scripts/lib/crypto-policy.mjs
+++ b/scripts/lib/crypto-policy.mjs
@@ -50,7 +50,7 @@ export function computePolicyDigest(rules) {
  * Adapted for stateless hook execution with file-based persistence.
  */
 export function createCryptoPolicyService(config) {
-  const csrgEndpoint = config.csrgEndpoint || config.iapEndpoint || "";
+  const csrgEndpoint = config.csrgEndpoint || "";
   const timeoutMs = config.timeoutMs || 30000;
   const stateFilePath = path.join(config.dataDir, "crypto-policy-state.json");
 

--- a/scripts/lib/daemon-client.mjs
+++ b/scripts/lib/daemon-client.mjs
@@ -1,0 +1,194 @@
+/**
+ * Phase 4 Tier B — daemon socket client.
+ *
+ * Used by hook-router.mjs as a fast path: connect to the local daemon over
+ * Unix socket, send the hook event as one JSON line, await one JSON line of
+ * response. Falls back to in-process handling on any error so the plugin
+ * never breaks if the daemon is missing/broken.
+ *
+ * Round-trip target: <5 ms p50, <20 ms p95 (vs 30-350 ms in-process).
+ *
+ * Audit DTOs go via fire-and-forget audit_enqueue messages — daemon batches
+ * and flushes asynchronously, hook process exits immediately.
+ */
+
+import { createConnection } from "node:net";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONNECT_TIMEOUT_MS = 1_500; // give up fast — we want to fall back if daemon is hung
+const REPLY_TIMEOUT_MS = 10_000; // reply may include a backend call (token mint, audit ship)
+const SPAWN_RETRY_DELAY_MS = 150;
+const SPAWN_RETRIES = 3;
+
+let nextReqId = 1;
+function makeReqId() { return `r-${process.pid}-${nextReqId++}-${Date.now()}`; }
+
+/**
+ * Connect to the daemon socket. Returns a connected socket or rejects on
+ * timeout / ECONNREFUSED / ENOENT (socket file missing).
+ */
+function connectOnce(socketPath) {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection(socketPath);
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("daemon connect timeout"));
+    }, CONNECT_TIMEOUT_MS);
+    sock.once("connect", () => { clearTimeout(timer); resolve(sock); });
+    sock.once("error", (err) => { clearTimeout(timer); reject(err); });
+  });
+}
+
+/**
+ * Spawn the daemon as a detached child and return once it accepts a
+ * connection (up to SPAWN_RETRIES × SPAWN_RETRY_DELAY_MS).
+ */
+async function spawnDaemon(socketPath, dataDir, config) {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const daemonScript = path.resolve(here, "..", "daemon.mjs");
+  // Pass the resolved dataDir explicitly so the spawned daemon writes its
+  // socket + PID file to the same place the client expects, even if the
+  // parent process was started with a different ARMORCLAUDE_DATA_DIR.
+  const childEnv = {
+    ...process.env,
+    ARMORCLAUDE_DATA_DIR: dataDir,
+    ARMORCLAUDE_RUNTIME_FILE: config?.runtimeFile || path.join(dataDir, "runtime.json"),
+    ARMORCLAUDE_POLICY_FILE: config?.policyFile || path.join(dataDir, "policy.json"),
+  };
+  const child = spawn(process.execPath, [daemonScript], {
+    detached: true,
+    stdio: "ignore",
+    cwd: dataDir,
+    env: childEnv,
+  });
+  child.unref();
+
+  for (let i = 0; i < SPAWN_RETRIES; i++) {
+    await new Promise((r) => setTimeout(r, SPAWN_RETRY_DELAY_MS));
+    if (existsSync(socketPath)) {
+      try {
+        const sock = await connectOnce(socketPath);
+        return sock;
+      } catch { /* try again */ }
+    }
+  }
+  throw new Error("daemon spawn did not become reachable");
+}
+
+/**
+ * Send one request, read one reply. Returns the parsed JSON or throws.
+ */
+function exchange(sock, payload) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        cleanup();
+        try { resolve(JSON.parse(buf.slice(0, nl))); }
+        catch (err) { reject(err); }
+      }
+    };
+    const onError = (err) => { cleanup(); reject(err); };
+    const cleanup = () => {
+      sock.off("data", onData);
+      sock.off("error", onError);
+      clearTimeout(timer);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("daemon reply timeout"));
+    }, REPLY_TIMEOUT_MS);
+    sock.on("data", onData);
+    sock.on("error", onError);
+    sock.write(JSON.stringify(payload) + "\n");
+  });
+}
+
+/**
+ * Public entry: dispatch a hook event through the daemon.
+ *
+ * @param {object} args
+ * @param {string} args.event           hook_event_name
+ * @param {object} args.input           full hook payload (matches handler signature)
+ * @param {object} args.config          loaded config (for socket path resolution)
+ * @returns {Promise<object|null>}      hook output JSON, or null
+ *
+ * Throws if the daemon is unreachable. Caller (hook-router.mjs) is expected
+ * to fall back to in-process dispatch on throw.
+ */
+export async function dispatchViaDaemon({ event, input, config }) {
+  const socketPath = path.join(config.dataDir, "daemon.sock");
+  const debug = !!config?.debug;
+  const t0 = debug ? Date.now() : 0;
+  let sock;
+  try {
+    sock = await connectOnce(socketPath);
+  } catch (err) {
+    if (err?.code === "ENOENT" || err?.code === "ECONNREFUSED") {
+      sock = await spawnDaemon(socketPath, config.dataDir, config);
+    } else {
+      throw err;
+    }
+  }
+  const tConnected = debug ? Date.now() : 0;
+  try {
+    const reqId = makeReqId();
+    const reply = await exchange(sock, { type: "hook", event, input, reqId });
+    if (debug) {
+      const tDone = Date.now();
+      process.stderr.write(
+        `[armorclaude] daemon dispatch event=${event} reqId=${reqId} connect=${tConnected - t0}ms total=${tDone - t0}ms\n`,
+      );
+    }
+    if (reply?.error) throw new Error(`daemon error: ${reply.error}`);
+    return reply?.output ?? null;
+  } finally {
+    try { sock.end(); } catch {}
+    try { sock.destroy(); } catch {}
+  }
+}
+
+/**
+ * Fire-and-forget audit enqueue. Returns immediately after the write
+ * completes (microseconds), does not wait for any reply. If the daemon is
+ * unreachable, returns false and the caller should fall back to a sync
+ * createAuditLog.
+ */
+export async function enqueueAuditViaDaemon({ dto, config }) {
+  const socketPath = path.join(config.dataDir, "daemon.sock");
+  let sock;
+  try {
+    sock = await connectOnce(socketPath);
+  } catch {
+    return false;
+  }
+  try {
+    sock.write(JSON.stringify({ type: "audit_enqueue", dto, reqId: makeReqId() }) + "\n");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try { sock.end(); } catch {}
+    try { sock.destroy(); } catch {}
+  }
+}
+
+/** Liveness probe — used by daemon-supervisor and tests. */
+export async function pingDaemon(config) {
+  const socketPath = path.join(config.dataDir, "daemon.sock");
+  let sock;
+  try { sock = await connectOnce(socketPath); }
+  catch { return null; }
+  try {
+    const reply = await exchange(sock, { type: "ping", reqId: makeReqId() });
+    return reply;
+  } finally {
+    try { sock.end(); } catch {}
+    try { sock.destroy(); } catch {}
+  }
+}

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -1,10 +1,11 @@
 import { isPlainObject, normalizeToolName, nowEpochSeconds, redactSecrets, sanitizeParams } from "./common.mjs";
-import { addPromptContext, blockPrompt, denyPreTool } from "./hook-output.mjs";
+import { addPromptContext, blockPrompt, denyPreTool, denyPreToolWithHint } from "./hook-output.mjs";
 import {
   checkIntentTokenPlan,
   checkToolAgainstPlan,
   extractAllowedActions,
   findPlanStepIndices,
+  getSdkClient,
   getSessionTokenUsedStepIndices,
   parseCsrgProofHeaders,
   recordSessionTokenUsedStepIndices,
@@ -12,7 +13,11 @@ import {
   resolveCsrgProofsFromToken,
   validateCsrgProofHeaders
 } from "./intent.mjs";
-import { createIapService } from "./iap-service.mjs";
+import {
+  createIapService,
+  reanchorViaSdk,
+  revokeViaSdk
+} from "./iap-service.mjs";
 import {
   applyPolicyCommand,
   computePolicyHash,
@@ -30,6 +35,7 @@ import { readJson } from "./fs-store.mjs";
 import { unlink } from "node:fs/promises";
 import path from "node:path";
 import {
+  appendTrustOp,
   getDiscoveredTools,
   getSession,
   loadRuntimeState,
@@ -37,6 +43,7 @@ import {
   upsertDiscoveredTool,
   upsertSession
 } from "./runtime-state.mjs";
+import { sha256Hex } from "./common.mjs";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -89,7 +96,7 @@ function isPolicyUpdateAllowed(config, input) {
       };
 }
 
-function mergeIntentIntoSession(session, intentResponse) {
+function mergeIntentIntoSession(session, intentResponse, config) {
   if (!intentResponse || intentResponse.skipped) {
     return session;
   }
@@ -104,7 +111,48 @@ function mergeIntentIntoSession(session, intentResponse) {
   if (Number.isFinite(intentResponse.expiresAt)) {
     next.expiresAt = intentResponse.expiresAt;
   }
+  // Stamp the API-key prefix on the session so the next hook can detect
+  // a key change and invalidate the cached token automatically. The
+  // prefix (first 16 chars) is the same value stored in api_keys.key_prefix
+  // and is safe to record — it's not the full secret.
+  if (typeof config?.apiKey === "string" && config.apiKey.length >= 16) {
+    next.apiKeyPrefix = config.apiKey.slice(0, 16);
+  }
   return next;
+}
+
+/**
+ * Auto-invalidate cached token when the API key has changed (different
+ * prefix). Triggered when the user edits ~/.armoriq/credentials.json or
+ * the launchctl ARMORIQ_API_KEY env. Without this, the plugin keeps
+ * reusing the old token even after the key changes — meaning audit rows
+ * land in the old org until the user manually clears runtime.json.
+ *
+ * Returns true if the cache was invalidated (caller should re-mint).
+ */
+function invalidateTokenOnKeyChange(session, config) {
+  if (!session?.intentTokenRaw) return false;
+  if (!session?.apiKeyPrefix) {
+    // Legacy session minted before this stamp existed; tolerate it once
+    // by stamping now and trusting the token.
+    if (typeof config?.apiKey === "string" && config.apiKey.length >= 16) {
+      session.apiKeyPrefix = config.apiKey.slice(0, 16);
+    }
+    return false;
+  }
+  const currentPrefix =
+    typeof config?.apiKey === "string" && config.apiKey.length >= 16
+      ? config.apiKey.slice(0, 16)
+      : "";
+  if (!currentPrefix || currentPrefix === session.apiKeyPrefix) return false;
+  // Drift detected — discard the cached token, plan, and expiry so the
+  // mint path runs fresh with the new key.
+  session.intentTokenRaw = "";
+  session.plan = undefined;
+  session.allowedActions = [];
+  session.expiresAt = 0;
+  delete session.apiKeyPrefix;
+  return true;
 }
 
 function readIntentTokenRaw(input, session) {
@@ -134,6 +182,53 @@ function debugLog(config, message) {
   if (config.debug) {
     process.stderr.write(`[armorclaude] ${message}\n`);
   }
+}
+
+const PLUGIN_PLUMBING_TOOLS = new Set([
+  "toolsearch",
+  "todowrite",
+  "listmcpresourcestool",
+  "readmcpresourcetool",
+  "exitplanmode",
+]);
+
+function isPluginPlumbingTool(toolName) {
+  if (typeof toolName !== "string" || !toolName) return false;
+  const norm = toolName.toLowerCase();
+  if (norm.startsWith("mcp__plugin_armorclaude_")) return true;
+  return PLUGIN_PLUMBING_TOOLS.has(norm);
+}
+
+/**
+ * Emit an audit row. Routing order:
+ *   1. daemon (if enabled and reachable) → fire-and-forget, daemon writes to WAL
+ *   2. WAL directly (if enabled, when daemon path fails) → durable, recoverable
+ *   3. synchronous HTTP POST (legacy fallback when both above are off/down)
+ *
+ * Returns a short label ("daemon" | "wal" | "http") for debug logging.
+ */
+async function emitAudit({ dto, config, iapService }) {
+  if (config.daemonEnabled) {
+    try {
+      const { enqueueAuditViaDaemon } = await import("./daemon-client.mjs");
+      const ok = await enqueueAuditViaDaemon({ dto, config });
+      if (ok) return "enqueued (daemon)";
+    } catch (err) {
+      debugLog(config, `audit daemon enqueue failed: ${err?.message ?? err}`);
+    }
+  }
+  if (config.auditWal) {
+    try {
+      const { createAuditWal } = await import("./audit-wal.mjs");
+      const wal = createAuditWal({ dataDir: config.dataDir });
+      await wal.appendLine(dto);
+      return "written (wal)";
+    } catch (err) {
+      debugLog(config, `audit WAL append failed: ${err?.message ?? err}`);
+    }
+  }
+  await iapService.createAuditLog(dto);
+  return "sent (http)";
 }
 
 /**
@@ -259,11 +354,32 @@ export async function handlePreToolUse(input, config) {
   //     not any suffix — an evil server called evil__policy_update would
   //     previously have been whitelisted. ---
   const norm = normalizeToolName(toolName);
-  const armorTools = ["register_intent_plan", "policy_read", "policy_update"];
-  const armorMcpPrefix = "mcp__armorclaude-policy__";
+  // ArmorClaude's own MCP tools — meta-tools for managing the plugin itself
+  // (declare a plan, inspect/update policy, drive Trust Update primitives).
+  // Blocking these creates a deadlock: the agent can't register a plan to
+  // unblock itself.
+  const armorTools = [
+    "register_intent_plan",
+    "policy_read",
+    "policy_update",
+    "trust_revoke",
+    "trust_reanchor",
+    "trust_delegate"
+  ];
+  // Claude Code surfaces MCP tools under different prefixes depending on how
+  // the server is loaded:
+  //   .mcp.json (top-level)       → mcp__<server>__<tool>
+  //   Claude Code plugin manifest → mcp__plugin_<plugin>_<server>__<tool>
+  // Match both. The deadlock the user hit ("intent drift: tool not in plan
+  // (mcp__plugin_armorclaude_armorclaude-policy__register_intent_plan)")
+  // was caused by the plugin-prefix variant being missed.
+  const armorMcpPrefixes = [
+    "mcp__armorclaude-policy__",
+    "mcp__plugin_armorclaude_armorclaude-policy__"
+  ];
   if (
     armorTools.some(
-      (t) => norm === t || norm === `${armorMcpPrefix}${t}`
+      (t) => norm === t || armorMcpPrefixes.some((pfx) => norm === `${pfx}${t}`)
     )
   ) {
     return null;
@@ -278,10 +394,27 @@ export async function handlePreToolUse(input, config) {
   //     no side effects on user files or systems. Blocking these makes the
   //     agent fight itself (e.g. ToolSearch is needed to fetch deferred MCP
   //     tool schemas before they can be called). ---
+  //
+  // Phase 4 A1 (2026-05-08): expanded with built-in read-only Claude Code
+  // tools that observe filesystem/network without mutating either. These get
+  // a hot-path return before any disk read, plan check, or backend HTTP —
+  // saves 30-350 ms per call. Bash is intentionally NOT here: it can do
+  // anything (rm -rf, curl, kill) and must continue through the full
+  // pipeline. Same for Edit/Write/NotebookEdit (mutating) and any MCP tool
+  // that isn't an ArmorClaude meta-tool (already handled above).
   const safeInternalTools = new Set([
+    // Claude Code coordination (no side effects)
     "toolsearch",
     "todowrite",
-    "listmcpresourcestool"
+    "listmcpresourcestool",
+    "readmcpresourcetool",
+    "exitplanmode",
+    // Built-in read-only filesystem/network tools
+    "read",
+    "grep",
+    "glob",
+    "websearch",
+    "webfetch"
   ]);
   if (safeInternalTools.has(norm)) {
     return null;
@@ -294,9 +427,70 @@ export async function handlePreToolUse(input, config) {
   // This load is reused for the rest of the PreToolUse handler instead of
   // reloading from disk below (fewer disk reads on the hot path).
   const runtimeState = await loadRuntimeState(config.runtimeFile);
-  const pendingPath = path.join(config.dataDir, "pending-plan.json");
-  const pending = await readJson(pendingPath, null);
+  const sessionPendingPath = sessionId
+    ? path.join(config.dataDir, `pending-plan.${sessionId}.json`)
+    : null;
+  const legacyPendingPath = path.join(config.dataDir, "pending-plan.json");
+  let pendingPath = sessionPendingPath;
+  let pending = sessionPendingPath ? await readJson(sessionPendingPath, null) : null;
+  if (!pending) {
+    pending = await readJson(legacyPendingPath, null);
+    pendingPath = legacyPendingPath;
+  }
   if (pending && (pending.tokenRaw || pending.plan)) {
+    // --- Auto-reanchor (Phase 3): if the previous plan + token exist for
+    // this session and the new plan hash differs, sign a ReAnchor delta
+    // *before* overwriting the cached plan. The audit log now reads
+    // Commit → ReAnchor → ... instead of orphan Commits.
+    if (config.autoReanchor && pending.plan) {
+      const priorSession = getSession(runtimeState, sessionId);
+      const priorTokenRaw = priorSession?.intentTokenRaw;
+      const priorPlan = priorSession?.plan;
+      if (priorTokenRaw && priorPlan) {
+        const localPriorHash = sha256Hex(JSON.stringify(priorPlan));
+        const localNextHash = sha256Hex(JSON.stringify(pending.plan));
+        if (localPriorHash !== localNextHash) {
+          let priorTokenObj;
+          try {
+            priorTokenObj = JSON.parse(priorTokenRaw);
+          } catch {
+            priorTokenObj = null;
+          }
+          if (priorTokenObj) {
+            const canonicalPriorHash =
+              priorTokenObj?.planHash ||
+              priorTokenObj?.rawToken?.token?.plan_hash ||
+              "";
+            const result = await reanchorViaSdk({
+              getClient: getSdkClient,
+              config,
+              intentToken: priorTokenObj,
+              updatedPlan: pending.plan,
+              reason: "armorclaude:plan-delta"
+            });
+            appendTrustOp(runtimeState, sessionId, {
+              operation: "ReAnchor",
+              trustId: result.trustId,
+              fromHash: result.fromHash || canonicalPriorHash || localPriorHash,
+              toHash: result.toHash || localNextHash,
+              reason: "plan delta detected at PreToolUse",
+              ok: result.ok
+            });
+            debugLog(
+              config,
+              `[trust] auto-reanchor ${result.ok ? "ok" : "failed"} prior=${localPriorHash.slice(0, 12)} new=${localNextHash.slice(0, 12)} trustId=${result.trustId || "n/a"}`
+            );
+            if (!result.ok) {
+              debugLog(
+                config,
+                `[trust] reanchor error: ${result.error || "unknown"}${result.status ? ` status=${result.status}` : ""}${result.body ? ` body=${JSON.stringify(result.body).slice(0, 300)}` : ""}`
+              );
+            }
+          }
+        }
+      }
+    }
+
     upsertSession(runtimeState, sessionId, {
       intentTokenRaw: pending.tokenRaw || "",
       plan: pending.plan,
@@ -343,6 +537,18 @@ export async function handlePreToolUse(input, config) {
   // --- Intent token verification ---
   // Reuse the runtimeState loaded above instead of re-reading from disk.
   const session = getSession(runtimeState, sessionId) || {};
+  // Auto-reload on credential change: if the cached token was minted with
+  // a different API key than the one currently configured, discard it so
+  // the mint path runs fresh below. Otherwise editing
+  // ~/.armoriq/credentials.json silently has no effect until the token
+  // expires.
+  if (invalidateTokenOnKeyChange(session, config)) {
+    debugLog(
+      config,
+      "API key changed (prefix differs); discarded cached token for fresh mint"
+    );
+    upsertSession(runtimeState, sessionId, session);
+  }
   let intentTokenRaw = readIntentTokenRaw(input, session);
   let localPlan = session.plan;
   let localExpiresAt = session.expiresAt;
@@ -381,7 +587,7 @@ export async function handlePreToolUse(input, config) {
         metadata: { source: "claude-code", trigger: "auto_refresh" }
       });
       if (!refreshed.skipped) {
-        const merged = mergeIntentIntoSession(session, refreshed);
+        const merged = mergeIntentIntoSession(session, refreshed, config);
         upsertSession(runtimeState, sessionId, merged);
         intentTokenRaw =
           typeof merged.intentTokenRaw === "string"
@@ -414,7 +620,7 @@ export async function handlePreToolUse(input, config) {
           trigger: "pre_tool_use"
         }
       });
-      const merged = mergeIntentIntoSession(session, intentResponse);
+      const merged = mergeIntentIntoSession(session, intentResponse, config);
       upsertSession(runtimeState, sessionId, merged);
       intentTokenRaw =
         typeof merged.intentTokenRaw === "string" ? merged.intentTokenRaw : "";
@@ -492,7 +698,7 @@ export async function handlePreToolUse(input, config) {
           verifyResult.reason || `ArmorClaude intent verification denied for ${toolName}`
         );
       }
-      const merged = mergeIntentIntoSession(session, verifyResult);
+      const merged = mergeIntentIntoSession(session, verifyResult, config);
       upsertSession(runtimeState, sessionId, merged);
       localPlan = merged.plan || localPlan;
       localExpiresAt = merged.expiresAt || localExpiresAt;
@@ -532,20 +738,31 @@ export async function handlePreToolUse(input, config) {
     const localCheck = checkToolAgainstPlan({
       plan: localPlan,
       toolName,
-      toolInput
+      toolInput,
+      strict: !!config.strictParamCheck
     });
     if (localCheck.allowed) {
       localPlanMatched = true;
     } else {
-      const deny = denyOrAllow(config, localCheck.reason || "ArmorClaude intent drift");
-      if (deny) {
-        return deny;
+      // Phase 4 A3: include the exact register_intent_plan JSON in the deny
+      // reason so the LLM auto-corrects in 1 follow-up turn.
+      if (shouldDeny(config)) {
+        return denyPreToolWithHint(
+          localCheck.reason || "ArmorClaude intent drift",
+          { toolName, toolInput, goal: session.lastPrompt, knownPlan: localPlan }
+        );
       }
     }
   }
 
   // --- Enforce intent requirement ---
   if (config.intentRequired && !remoteAllowed && !tokenCheckMatched && !localPlanMatched) {
+    if (shouldDeny(config)) {
+      return denyPreToolWithHint(
+        "ArmorClaude intent plan missing for this session",
+        { toolName, toolInput, goal: session.lastPrompt }
+      );
+    }
     const deny = denyOrAllow(config, "ArmorClaude intent plan missing for this session");
     if (deny) {
       return deny;
@@ -604,7 +821,7 @@ async function handleExitPlanModeCapture(input, sessionId, config) {
             validitySeconds: config.validitySeconds,
             metadata: { source: "claude-code", planning: "plan-mode" }
           });
-          const merged = mergeIntentIntoSession(session, intentResponse);
+          const merged = mergeIntentIntoSession(session, intentResponse, config);
           upsertSession(runtimeState, sessionId, merged);
         } else {
           // Store plan locally without ArmorIQ token
@@ -637,12 +854,15 @@ export async function handlePostToolUse(input, config) {
   const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
   if (!toolName) return null;
 
+  if (isPluginPlumbingTool(toolName)) return null;
+
   try {
     const runtimeState = await loadRuntimeState(config.runtimeFile);
     const session = getSession(runtimeState, sessionId) || {};
     const iapService = createIapService(config);
 
     const intentTokenRaw = session.intentTokenRaw || "";
+    if (!intentTokenRaw) return null;
     let token = intentTokenRaw;
     // Extract JWT if embedded in JSON envelope
     if (intentTokenRaw.startsWith("{")) {
@@ -669,8 +889,12 @@ export async function handlePostToolUse(input, config) {
       duration_ms: 0
     };
 
-    await iapService.createAuditLog(dto);
-    debugLog(config, `audit log sent for ${toolName} step=${stepIdx}`);
+    // Phase 4 A4 (via Tier B): if daemon is enabled, enqueue the audit DTO
+    // for fire-and-forget batched flush. This actually delivers the
+    // latency win — without daemon, we still need to await the POST because
+    // the hook process can't exit while a socket is open.
+    const target = await emitAudit({ dto, config, iapService });
+    debugLog(config, `audit log ${target} for ${toolName} step=${stepIdx}`);
   } catch (error) {
     // Audit is best-effort — don't block
     debugLog(config, `audit log failed: ${error}`);
@@ -692,12 +916,15 @@ export async function handlePostToolUseFailure(input, config) {
   const toolName = typeof input.tool_name === "string" ? input.tool_name : "";
   if (!toolName) return null;
 
+  if (isPluginPlumbingTool(toolName)) return null;
+
   try {
     const runtimeState = await loadRuntimeState(config.runtimeFile);
     const session = getSession(runtimeState, sessionId) || {};
     const iapService = createIapService(config);
 
     const intentTokenRaw = session.intentTokenRaw || "";
+    if (!intentTokenRaw) return null;
     let token = intentTokenRaw;
     if (intentTokenRaw.startsWith("{")) {
       try {
@@ -721,8 +948,8 @@ export async function handlePostToolUseFailure(input, config) {
       duration_ms: 0
     };
 
-    await iapService.createAuditLog(dto);
-    debugLog(config, `audit log (failure) sent for ${toolName}`);
+    const target = await emitAudit({ dto, config, iapService });
+    debugLog(config, `audit log (failure) ${target} for ${toolName}`);
   } catch (error) {
     debugLog(config, `audit log (failure) failed: ${error}`);
   }
@@ -747,6 +974,59 @@ export async function handleStop(input, config) {
     debugLog(config, "intent token expired during turn");
   }
 
+  // --- Phase 4 A2: proactive token refresh at turn boundary ---
+  // The original refresh fires INSIDE handlePreToolUse when a token is near
+  // expiry (engine.mjs:444-486). That's the worst place — Claude is mid-turn
+  // and every subsequent tool waits the 150-300 ms HTTP RTT.
+  //
+  // Move that refresh here, to Stop hook (between turns). The user is reading
+  // Claude's output; nothing is gated. Next turn starts with a fresh token,
+  // zero latency on the PreToolUse critical path. The PreToolUse refresh
+  // stays as a fallback for edge cases (very short turns, long pauses).
+  const refreshThresholdSec = Number.isFinite(config.refreshThresholdSeconds)
+    ? config.refreshThresholdSeconds
+    : 30;
+  // Refresh more aggressively at turn boundary than mid-turn — predict the
+  // user's next turn could fire a tool within ~2-3 minutes, so refresh if
+  // less than `refreshThresholdSec * 4` left.
+  const stopRefreshThresholdSec = refreshThresholdSec * 4;
+  const tokenLeft = Number.isFinite(session.expiresAt)
+    ? session.expiresAt - nowEpochSeconds()
+    : 0;
+  if (
+    session.intentTokenRaw &&
+    isPlainObject(session.plan) &&
+    tokenLeft > 0 &&
+    tokenLeft < stopRefreshThresholdSec &&
+    (config.intentEndpoint || (config.useSdkIntent && config.apiKey))
+  ) {
+    try {
+      const policyState = await loadPolicyState(config.policyFile);
+      const refreshed = await requestIntent(config, {
+        prompt: session.lastPrompt || "Stop-hook proactive refresh",
+        plan: session.plan,
+        session_id: sessionId,
+        policy_hash: computePolicyHash(policyState.policy),
+        policy: policyState.policy,
+        validitySeconds: config.validitySeconds,
+        metadata: { source: "claude-code", trigger: "stop_proactive_refresh" }
+      });
+      if (!refreshed.skipped) {
+        const merged = mergeIntentIntoSession(session, refreshed, config);
+        upsertSession(runtimeState, sessionId, merged);
+        debugLog(
+          config,
+          `[A2] token pre-refreshed at Stop, was ${tokenLeft}s left, threshold=${stopRefreshThresholdSec}s`
+        );
+      }
+    } catch (error) {
+      // Best-effort. If refresh fails, the in-line refresh in PreToolUse
+      // will fire on the next tool call as a safety net.
+      const msg = error instanceof Error ? error.message : String(error);
+      debugLog(config, `[A2] stop-refresh failed (will fall back to in-line): ${msg}`);
+    }
+  }
+
   upsertSession(runtimeState, sessionId, {
     lastStopAt: nowEpochSeconds()
   });
@@ -763,7 +1043,40 @@ export async function handleSessionEnd(input, config) {
   if (!sessionId) return null;
 
   const runtimeState = await loadRuntimeState(config.runtimeFile);
-  // Remove the session entirely
+  const session = runtimeState.sessions ? runtimeState.sessions[sessionId] : undefined;
+
+  // --- Auto-revoke (Phase 3): kill the active intent token at session end
+  // so the 15-minute lifetime can't outlive the Claude Code session. The
+  // SDK's revoke is best-effort; failure logs but doesn't block cleanup.
+  if (config.autoRevokeOnEnd && session?.intentTokenRaw) {
+    if (!Number.isFinite(session.expiresAt) || session.expiresAt > nowEpochSeconds()) {
+      let intentToken = null;
+      try {
+        intentToken = JSON.parse(session.intentTokenRaw);
+      } catch {
+        intentToken = null;
+      }
+      const result = await revokeViaSdk({
+        getClient: getSdkClient,
+        config,
+        intentToken,
+        reason: "armorclaude:session-ended",
+        cascade: false
+      });
+      appendTrustOp(runtimeState, sessionId, {
+        operation: "Revoke",
+        trustId: result.trustId,
+        reason: "session ended",
+        ok: result.ok
+      });
+      debugLog(
+        config,
+        `[trust] session-end revoke ${result.ok ? "ok" : "failed"} trustId=${result.trustId || "n/a"}`
+      );
+    }
+  }
+
+  // Remove the session entirely (after the trust op was logged + persisted)
   if (runtimeState.sessions && runtimeState.sessions[sessionId]) {
     delete runtimeState.sessions[sessionId];
   }

--- a/scripts/lib/hook-output.mjs
+++ b/scripts/lib/hook-output.mjs
@@ -8,6 +8,59 @@ export function denyPreTool(reason) {
   };
 }
 
+/**
+ * Phase 4 A3: actionable deny output.
+ *
+ * When a tool is blocked by drift / missing plan / missing token, return a
+ * deny that *also* tells the LLM the exact JSON to call register_intent_plan
+ * with. Claude reads `permissionDecisionReason` and can self-correct in 1
+ * follow-up turn instead of 3 (deny → re-prompt user → re-prompt for the
+ * right format → finally register).
+ *
+ * @param {string} reason            free-form explanation
+ * @param {object} args
+ * @param {string} args.toolName     the tool that was blocked (will end up in the suggested plan)
+ * @param {object} [args.toolInput]  the exact arguments — will be embedded into metadata.inputs
+ * @param {string} [args.goal]       inferred goal from session.lastPrompt or the tool name
+ * @param {object} [args.knownPlan]  the currently-cached plan (if any) — we'll suggest extending it
+ */
+export function denyPreToolWithHint(reason, args = {}) {
+  const { toolName = "Tool", toolInput, goal, knownPlan } = args;
+  const newStep = {
+    action: toolName,
+    description: `Use ${toolName} to ${goal || "make progress on the user's task"}`,
+  };
+  if (toolInput && typeof toolInput === "object" && Object.keys(toolInput).length > 0) {
+    // Don't pin params strictly — Phase 3 made metadata.inputs advisory.
+    // Include them for documentation only.
+    newStep.metadata = { inputs: toolInput };
+  }
+  let suggestedPlan;
+  if (knownPlan && Array.isArray(knownPlan.steps) && knownPlan.steps.length > 0) {
+    suggestedPlan = {
+      goal: knownPlan.goal || goal || "extend prior plan",
+      steps: [...knownPlan.steps, newStep],
+    };
+  } else {
+    suggestedPlan = {
+      goal: goal || `Run ${toolName}`,
+      steps: [newStep],
+    };
+  }
+  const hint =
+    `\n\nTo unblock: call register_intent_plan with this JSON:\n` +
+    "```json\n" +
+    JSON.stringify(suggestedPlan, null, 2) +
+    "\n```";
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason + hint,
+    },
+  };
+}
+
 export function blockPrompt(reason) {
   return {
     decision: "block",

--- a/scripts/lib/iap-service.mjs
+++ b/scripts/lib/iap-service.mjs
@@ -22,7 +22,7 @@ import {
  */
 export function createIapService(config) {
   const backendEndpoint = config.backendEndpoint || config.verifyStepEndpoint?.replace(/\/iap\/verify-step$/, "") || "";
-  const csrgEndpoint = config.csrgEndpoint || config.iapEndpoint || "";
+  const csrgEndpoint = config.csrgEndpoint || "";
   const timeoutMs = config.timeoutMs || 8000;
   const headers = buildAuthHeaders(config);
 
@@ -162,6 +162,33 @@ export function createIapService(config) {
       return response.data;
     },
 
+    /**
+     * Phase 4 C2: send N audit DTOs in one HTTP roundtrip.
+     * Used by armorclaude-daemon's audit-buffer flush. The daemon batches
+     * up to 100 rows or 5s, whichever first, then ships them here.
+     *
+     * Returns { written, failures } so the daemon knows whether to
+     * re-queue any rows that failed.
+     */
+    async createAuditLogBatch(rows) {
+      if (!Array.isArray(rows) || rows.length === 0) {
+        return { written: 0, failures: [] };
+      }
+      const response = await postJson(
+        `${backendEndpoint}/iap/audit/batch`,
+        { rows },
+        headers,
+        timeoutMs
+      );
+      if (!response.ok || !response.data) {
+        const message = response.text
+          ? `IAP audit batch failed: ${response.text}`
+          : `IAP audit batch failed with status ${response.status}`;
+        throw new Error(message);
+      }
+      return response.data;
+    },
+
     csrgProofsRequired() {
       return Boolean(config.requireCsrgProofs);
     },
@@ -221,4 +248,122 @@ function parseStepIndexFromPath(path) {
   if (!match) return null;
   const index = Number.parseInt(match[1] || "", 10);
   return Number.isFinite(index) ? index : null;
+}
+
+// ---------------------------------------------------------------------------
+// Trust Update primitives (Phase 3) — thin wrappers over the SDK methods
+// already shipped in @armoriq/sdk's Client. All three are best-effort: a
+// failure logs and returns { ok: false }; it never throws to the caller.
+// The hook handlers must not block on Trust Update plumbing failures.
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign a ReAnchor delta linking the previous plan hash to the new one.
+ * Returns { ok, trustId?, fromHash?, toHash? }.
+ *
+ * @param {object} args
+ * @param {(config:any)=>any} args.getClient — getSdkClient resolver (passed in
+ *   to avoid a circular import between iap-service.mjs and intent.mjs).
+ * @param {object} args.config
+ * @param {object} args.intentToken — current intent token (raw object, parsed)
+ * @param {object} args.updatedPlan — the new plan structure
+ * @param {string} [args.reason]
+ */
+export async function reanchorViaSdk({ getClient, config, intentToken, updatedPlan, reason }) {
+  if (!intentToken || !updatedPlan) {
+    return { ok: false, error: "missing intentToken or updatedPlan" };
+  }
+  if (!config?.apiKey || !config?.useSdkIntent) {
+    return { ok: false, error: "sdk-disabled" };
+  }
+  try {
+    const client = getClient(config);
+    if (typeof client?.reanchor !== "function") {
+      return { ok: false, error: "client.reanchor not available" };
+    }
+    const result = await client.reanchor(intentToken, updatedPlan, reason);
+    return {
+      ok: true,
+      trustId: result?.trustId,
+      fromHash: result?.delta?.payload?.from_hash,
+      toHash: result?.delta?.payload?.to_hash
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err?.message || String(err),
+      status: err?.response?.status,
+      body: err?.response?.data
+    };
+  }
+}
+
+/**
+ * Sign a Revoke delta for the given token, propagating to PEPs. Accepts
+ * either a full intent token object OR a planId/tokenId for operator-driven
+ * revocation (the controller in conmap-auto handles either shape).
+ */
+export async function revokeViaSdk({ getClient, config, intentToken, planId, tokenId, reason, cascade }) {
+  if (!config?.apiKey || !config?.useSdkIntent) {
+    return { ok: false, error: "sdk-disabled" };
+  }
+  try {
+    const client = getClient(config);
+    if (typeof client?.revoke !== "function") {
+      return { ok: false, error: "client.revoke not available" };
+    }
+    // The SDK's revoke signature takes an IntentToken; if only planId/tokenId
+    // is available (operator path), synthesize a minimal token shape that the
+    // backend's relaxed RevokeDto will accept.
+    const token = intentToken ?? {
+      tokenId: tokenId,
+      token_id: tokenId,
+      planHash: undefined,
+      signature: tokenId || planId || "unknown",
+      issuedAt: 0,
+      expiresAt: 0,
+      policy: {},
+      compositeIdentity: "",
+      stepProofs: [],
+      totalSteps: 0,
+      rawToken: { token: { token_id: tokenId, planId } }
+    };
+    const result = await client.revoke(token, reason || "armorclaude", { cascade: !!cascade, planId });
+    return {
+      ok: true,
+      trustId: result?.trustId,
+      cascadedRevocations: result?.cascadedRevocations
+    };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
+}
+
+/**
+ * Issue a subtree-bounded delegated token + Merkle inclusion proof.
+ */
+export async function delegateSubtreeViaSdk({ getClient, config, intentToken, opts }) {
+  if (!intentToken || !opts?.delegatePublicKey || !opts?.subtreePath) {
+    return { ok: false, error: "missing intentToken / delegatePublicKey / subtreePath" };
+  }
+  if (!config?.apiKey || !config?.useSdkIntent) {
+    return { ok: false, error: "sdk-disabled" };
+  }
+  try {
+    const client = getClient(config);
+    if (typeof client?.delegateSubtree !== "function") {
+      return { ok: false, error: "client.delegateSubtree not available" };
+    }
+    const result = await client.delegateSubtree(intentToken, opts);
+    return {
+      ok: true,
+      trustId: result?.trustId,
+      delegationId: result?.delegationId,
+      inclusionProof: result?.inclusionProof,
+      subtreeRoot: result?.subtreeRoot,
+      delegatedToken: result?.delegatedToken
+    };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  }
 }

--- a/scripts/lib/intent.mjs
+++ b/scripts/lib/intent.mjs
@@ -19,27 +19,32 @@ function buildSdkClientKey(config) {
     config.userId,
     config.agentId,
     config.contextId,
-    config.iapEndpoint,
-    config.proxyEndpoint,
     config.backendEndpoint,
+    config.csrgEndpoint,
     config.useProduction ? "prod" : "dev"
   ].join("|");
 }
 
-function getSdkClient(config) {
+export function getSdkClient(config) {
   const key = buildSdkClientKey(config);
   const cached = sdkClientCache.get(key);
   if (cached) {
     return cached;
   }
+  // SDK has separate iapEndpoint/proxyEndpoint params for legacy reasons
+  // (the SDK can also act as a tool dispatcher via invokeWithPolicy, which
+  // armorclaude never uses). We pass csrgEndpoint as iapEndpoint because
+  // the SDK's `/delegation/create` route lives on csrg-iap. We don't pass
+  // proxyEndpoint at all — armorclaude observes tool calls via hooks, the
+  // proxy is never hit. SDK falls back to its own default if a customer
+  // ever spawns an invokeWithPolicy path.
   const client = new ArmorIQClient({
     apiKey: config.apiKey,
     userId: config.userId,
     agentId: config.agentId,
     contextId: config.contextId,
     useProduction: config.useProduction,
-    iapEndpoint: config.iapEndpoint,
-    proxyEndpoint: config.proxyEndpoint,
+    iapEndpoint: config.csrgEndpoint,
     backendEndpoint: config.backendEndpoint,
     timeout: config.timeoutMs,
     maxRetries: config.maxRetries,
@@ -183,7 +188,7 @@ export function findPlanStepIndices(plan, toolName, toolParams) {
   return { matches, paramMatches };
 }
 
-export function checkToolAgainstPlan({ plan, toolName, toolInput }) {
+export function checkToolAgainstPlan({ plan, toolName, toolInput, strict = false }) {
   const normalizedTool = normalizeToolName(toolName);
   const steps = Array.isArray(plan?.steps) ? plan.steps : [];
   if (!steps.length) {
@@ -221,7 +226,12 @@ export function checkToolAgainstPlan({ plan, toolName, toolInput }) {
       return { allowed: true };
     }
   }
-  if (sawConstrainedMatch) {
+  // Permissive by default: declared metadata.inputs are advisory, not contractual.
+  // LLM plans are predictions; treating exact param mismatch as a security
+  // violation produces too many false positives (see live screenshot from the
+  // user's other Claude Code session). Set strict=true (or
+  // ARMORCLAUDE_STRICT_PARAM_CHECK=true via the engine handler) to opt back in.
+  if (sawConstrainedMatch && strict) {
     return {
       allowed: false,
       reason: `ArmorClaude intent mismatch: parameters not allowed for ${toolName}`

--- a/scripts/lib/runtime-state.mjs
+++ b/scripts/lib/runtime-state.mjs
@@ -29,11 +29,18 @@ export function upsertSession(runtimeState, sessionId, patch) {
   return runtimeState.sessions[sessionId];
 }
 
+const POST_EXPIRY_GRACE_SECONDS = 60 * 60;
+
 export function pruneSessions(runtimeState) {
   const now = nowEpochSeconds();
   for (const [sessionId, session] of Object.entries(runtimeState.sessions)) {
     const updatedAt = Number.isFinite(session.updatedAt) ? session.updatedAt : 0;
     if (now - updatedAt > MAX_SESSION_AGE_SECONDS) {
+      delete runtimeState.sessions[sessionId];
+      continue;
+    }
+    const expiresAt = Number.isFinite(session.expiresAt) ? session.expiresAt : 0;
+    if (expiresAt > 0 && now - expiresAt > POST_EXPIRY_GRACE_SECONDS) {
       delete runtimeState.sessions[sessionId];
     }
   }
@@ -66,5 +73,37 @@ export function getDiscoveredTools(runtimeState) {
   return Array.isArray(runtimeState?.discoveredTools)
     ? runtimeState.discoveredTools
     : [];
+}
+
+// ---------------------------------------------------------------------------
+// Trust Update audit — append-only log of ReAnchor / Delegate / Revoke deltas
+// produced by armorClaude's automatic Trust Update integration. Mirrors the
+// IAP backend's TrustDelta table for in-process visibility and tests.
+// ---------------------------------------------------------------------------
+
+export function appendTrustOp(runtimeState, sessionId, op) {
+  if (!sessionId || !op || typeof op !== "object") return;
+  const session = getSession(runtimeState, sessionId);
+  if (!session) return;
+  if (!Array.isArray(session.trustOpsLog)) {
+    session.trustOpsLog = [];
+  }
+  const entry = {
+    ts: nowEpochSeconds(),
+    operation: typeof op.operation === "string" ? op.operation : "Unknown",
+    trustId: typeof op.trustId === "string" ? op.trustId : undefined,
+    fromHash: typeof op.fromHash === "string" ? op.fromHash : undefined,
+    toHash: typeof op.toHash === "string" ? op.toHash : undefined,
+    reason: typeof op.reason === "string" ? op.reason : undefined,
+    ok: op.ok !== false
+  };
+  session.trustOpsLog.push(entry);
+  session.updatedAt = entry.ts;
+  return entry;
+}
+
+export function getTrustOps(runtimeState, sessionId) {
+  const session = getSession(runtimeState, sessionId);
+  return Array.isArray(session?.trustOpsLog) ? session.trustOpsLog : [];
 }
 

--- a/scripts/policy-mcp.mjs
+++ b/scripts/policy-mcp.mjs
@@ -4,7 +4,9 @@ import path from "node:path";
 import { z } from "zod";
 import { loadConfig } from "./lib/config.mjs";
 import { writeJson } from "./lib/fs-store.mjs";
-import { extractAllowedActions, requestIntent } from "./lib/intent.mjs";
+import { extractAllowedActions, getSdkClient, requestIntent } from "./lib/intent.mjs";
+import { delegateSubtreeViaSdk, reanchorViaSdk, revokeViaSdk } from "./lib/iap-service.mjs";
+import { loadRuntimeState, appendTrustOp, saveRuntimeState } from "./lib/runtime-state.mjs";
 import { INTENT_PLAN_ZOD, PLAN_STEP_SCHEMA, normalizeIntentPlan } from "./lib/intent-schema.mjs";
 import { applyPolicyCommand, computePolicyHash, loadPolicyState, parsePolicyTextCommand } from "./lib/policy.mjs";
 
@@ -194,7 +196,7 @@ async function run() {
 
       // Send to ArmorIQ for signed intent token (if SDK/endpoint configured)
       let intentResult = { skipped: true };
-      if (config.intentEndpoint || (config.useSdkIntent && config.apiKey)) {
+      if (config.intentEndpoint || config.apiKey) {
         try {
           const policyState = await loadPolicyState(config.policyFile);
           intentResult = await requestIntent(config, {
@@ -212,9 +214,13 @@ async function run() {
         }
       }
 
-      // Write to pending-plan.json — PreToolUse hook will pick it up
-      const pendingPath = path.join(config.dataDir, "pending-plan.json");
+      const sessionId = process.env.CLAUDE_CODE_SESSION_ID || "";
+      const pendingFile = sessionId
+        ? `pending-plan.${sessionId}.json`
+        : "pending-plan.json";
+      const pendingPath = path.join(config.dataDir, pendingFile);
       await writeJson(pendingPath, {
+        sessionId: sessionId || undefined,
         plan: intentResult.plan || plan,
         tokenRaw: intentResult.tokenRaw || "",
         allowedActions: Array.from(extractAllowedActions(intentResult.plan || plan)),
@@ -229,6 +235,200 @@ async function run() {
       return toTextResult(
         `Intent registered: ${plan.steps.length} steps. ${tokenInfo}`,
         { steps: plan.steps.length, goal: parsed.data.goal }
+      );
+    }
+  );
+
+  // -----------------------------------------------------------------
+  // Trust Update primitives — operator/LLM can revoke, reanchor, or
+  // delegate the active intent token directly from a Claude Code chat.
+  // All three resolve the active session by reading the runtime file
+  // (the MCP server is a long-lived stdio process, separate from the
+  // hook handlers, so we re-read on every call).
+  // -----------------------------------------------------------------
+
+  async function resolveActiveSession() {
+    const config = loadConfig();
+    const runtimeState = await loadRuntimeState(config.runtimeFile);
+    const sessions = runtimeState.sessions || {};
+    let chosen = null;
+    let chosenId = null;
+    for (const [sid, s] of Object.entries(sessions)) {
+      if (!chosen || (s.updatedAt || 0) > (chosen.updatedAt || 0)) {
+        chosen = s;
+        chosenId = sid;
+      }
+    }
+    return { config, runtimeState, sessionId: chosenId, session: chosen };
+  }
+
+  function parseToken(raw) {
+    if (!raw || typeof raw !== "string") return null;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  server.registerTool(
+    "trust_revoke",
+    {
+      title: "Revoke active intent token (Trust Update)",
+      description:
+        "Sign and broadcast a revocation delta for the currently active " +
+        "intent token. Within Δ (paper-measured ~55 ms) every PEP in the " +
+        "fleet refuses the token. Use when the user says \"stop\" or when " +
+        "the plan has gone wrong.",
+      inputSchema: {
+        reason: z.string().min(1).describe("Why this revocation is happening"),
+        cascade: z
+          .boolean()
+          .optional()
+          .describe("If true, also revoke any subtree-delegated child tokens")
+      }
+    },
+    async (args) => {
+      const { config, runtimeState, sessionId, session } = await resolveActiveSession();
+      if (!session) {
+        return toTextResult("No active session — nothing to revoke.");
+      }
+      const intentToken = parseToken(session.intentTokenRaw);
+      const result = await revokeViaSdk({
+        getClient: getSdkClient,
+        config,
+        intentToken,
+        reason: args.reason,
+        cascade: args.cascade
+      });
+      appendTrustOp(runtimeState, sessionId, {
+        operation: "Revoke",
+        trustId: result.trustId,
+        reason: args.reason,
+        ok: result.ok
+      });
+      await saveRuntimeState(config.runtimeFile, runtimeState);
+      if (!result.ok) {
+        return toTextResult(`Revoke failed: ${result.error || "unknown error"}`);
+      }
+      const cascadedNote = result.cascadedRevocations?.length
+        ? ` (${result.cascadedRevocations.length} descendants cascaded)`
+        : "";
+      return toTextResult(
+        `Token revoked. trustId=${result.trustId || "n/a"}${cascadedNote}`,
+        { trustId: result.trustId, cascaded: result.cascadedRevocations || [] }
+      );
+    }
+  );
+
+  server.registerTool(
+    "trust_reanchor",
+    {
+      title: "Re-anchor intent plan (Trust Update)",
+      description:
+        "Sign a delta δ(h_P → h'_P) for an updated plan, preserving the " +
+        "tamper-evident lineage in the IAP audit log. Re-mints the working " +
+        "token so subsequent tool calls succeed.",
+      inputSchema: {
+        updatedPlan: INTENT_PLAN_ZOD.describe("The revised plan structure"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Why the plan changed — surfaces in the audit timeline")
+      }
+    },
+    async (args) => {
+      const parsed = INTENT_PLAN_ZOD.safeParse(args.updatedPlan);
+      if (!parsed.success) {
+        return toTextResult(`Plan rejected: ${parsed.error.message}`);
+      }
+      const updatedPlan = normalizeIntentPlan(parsed.data);
+      const { config, runtimeState, sessionId, session } = await resolveActiveSession();
+      if (!session) {
+        return toTextResult("No active session — nothing to reanchor.");
+      }
+      const intentToken = parseToken(session.intentTokenRaw);
+      if (!intentToken) {
+        return toTextResult("No intent token in session state.");
+      }
+      const result = await reanchorViaSdk({
+        getClient: getSdkClient,
+        config,
+        intentToken,
+        updatedPlan,
+        reason: args.reason || "armorclaude:operator-reanchor"
+      });
+      appendTrustOp(runtimeState, sessionId, {
+        operation: "ReAnchor",
+        trustId: result.trustId,
+        fromHash: result.fromHash,
+        toHash: result.toHash,
+        reason: args.reason,
+        ok: result.ok
+      });
+      await saveRuntimeState(config.runtimeFile, runtimeState);
+      if (!result.ok) {
+        return toTextResult(`Reanchor failed: ${result.error || "unknown error"}`);
+      }
+      return toTextResult(
+        `ReAnchor recorded. trustId=${result.trustId || "n/a"} delta(${(result.fromHash || "").slice(0, 12)} → ${(result.toHash || "").slice(0, 12)})`,
+        { trustId: result.trustId, fromHash: result.fromHash, toHash: result.toHash }
+      );
+    }
+  );
+
+  server.registerTool(
+    "trust_delegate",
+    {
+      title: "Delegate subtree of plan (Trust Update)",
+      description:
+        "Issue a subtree-bounded child token plus a Merkle inclusion proof. " +
+        "The sub-agent receives authority confined to the named subtree path.",
+      inputSchema: {
+        delegatePublicKey: z.string().min(1).describe("Public key of the sub-agent that will hold the child token"),
+        subtreePath: z.string().min(1).describe("Plan subtree this delegation covers, e.g. /steps/[1]"),
+        validitySeconds: z.number().int().positive().optional().describe("Override the default validity"),
+        targetAgent: z.string().optional().describe("Human-readable label for the sub-agent")
+      }
+    },
+    async (args) => {
+      const { config, runtimeState, sessionId, session } = await resolveActiveSession();
+      if (!session) {
+        return toTextResult("No active session — nothing to delegate.");
+      }
+      const intentToken = parseToken(session.intentTokenRaw);
+      if (!intentToken) {
+        return toTextResult("No intent token in session state.");
+      }
+      const result = await delegateSubtreeViaSdk({
+        getClient: getSdkClient,
+        config,
+        intentToken,
+        opts: {
+          delegatePublicKey: args.delegatePublicKey,
+          subtreePath: args.subtreePath,
+          validitySeconds: args.validitySeconds,
+          targetAgent: args.targetAgent
+        }
+      });
+      appendTrustOp(runtimeState, sessionId, {
+        operation: "Delegate",
+        trustId: result.trustId,
+        reason: `delegate to ${args.targetAgent || args.delegatePublicKey.slice(0, 16)}…`,
+        ok: result.ok
+      });
+      await saveRuntimeState(config.runtimeFile, runtimeState);
+      if (!result.ok) {
+        return toTextResult(`Delegate failed: ${result.error || "unknown error"}`);
+      }
+      return toTextResult(
+        `Delegation issued. trustId=${result.trustId || "n/a"} subtreePath=${args.subtreePath} (delegationId=${result.delegationId || "n/a"})`,
+        {
+          trustId: result.trustId,
+          delegationId: result.delegationId,
+          subtreeRoot: result.subtreeRoot,
+          inclusionProofLength: Array.isArray(result.inclusionProof) ? result.inclusionProof.length : 0
+        }
       );
     }
   );

--- a/tests/audit-wal.test.mjs
+++ b/tests/audit-wal.test.mjs
@@ -1,0 +1,197 @@
+/**
+ * Audit WAL tests — exercise the on-disk write-ahead log without spinning
+ * up the daemon. Covers:
+ *   • append/read round-trip
+ *   • offset persistence across "restarts" (new wal instance, same dataDir)
+ *   • rotation when current.jsonl exceeds size threshold
+ *   • crash-replay: rows survive a missing offset advance
+ *   • malformed-line skip (the stream doesn't permanently jam)
+ *   • disk-full / row-too-large rejection
+ *   • concurrent append safety (POSIX O_APPEND atomicity assertion)
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, stat } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createAuditWal } from "../scripts/lib/audit-wal.mjs";
+
+async function fixture() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-wal-"));
+  return { dir, wal: createAuditWal({ dataDir: dir }) };
+}
+
+test("appendLine + readBatch round-trip", async () => {
+  const { wal } = await fixture();
+  await wal.appendLine({ id: 1, action: "a" });
+  await wal.appendLine({ id: 2, action: "b" });
+  await wal.appendLine({ id: 3, action: "c" });
+
+  const { rows, endOffset } = await wal.readBatch(100);
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].id, 1);
+  assert.equal(rows[2].action, "c");
+  assert.ok(endOffset > 0);
+});
+
+test("advanceOffset persists across new wal instance (restart)", async () => {
+  const { dir, wal } = await fixture();
+  await wal.appendLine({ id: 1 });
+  await wal.appendLine({ id: 2 });
+  const { rows, endOffset } = await wal.readBatch();
+  assert.equal(rows.length, 2);
+  await wal.advanceOffset(endOffset);
+
+  // Simulate process restart: brand new wal handle, same dir.
+  const wal2 = createAuditWal({ dataDir: dir });
+  const second = await wal2.readBatch();
+  assert.equal(second.rows.length, 0, "shipped rows should not be re-read");
+
+  await wal2.appendLine({ id: 3 });
+  const third = await wal2.readBatch();
+  assert.equal(third.rows.length, 1);
+  assert.equal(third.rows[0].id, 3);
+});
+
+test("crash-replay: missing advance leaves rows for next read", async () => {
+  const { dir, wal } = await fixture();
+  await wal.appendLine({ id: 1 });
+  await wal.appendLine({ id: 2 });
+  // Read but don't advance — simulating crash between disk write and ack.
+  await wal.readBatch();
+
+  const wal2 = createAuditWal({ dataDir: dir });
+  const { rows } = await wal2.readBatch();
+  assert.equal(rows.length, 2, "uncommitted rows are replayed");
+  assert.deepEqual(rows.map((r) => r.id), [1, 2]);
+});
+
+test("rotation: oversize triggers archive + offset reset", async () => {
+  const { dir } = await fixture();
+  const wal = createAuditWal({ dataDir: dir, rotateBytes: 200 });
+
+  // Each row ~50 bytes; 6 rows ~= 300 bytes (over the 200-byte cap)
+  for (let i = 0; i < 6; i++) {
+    await wal.appendLine({ id: i, pad: "x".repeat(20) });
+  }
+  const { rows, endOffset } = await wal.readBatch(100);
+  assert.equal(rows.length, 6);
+  await wal.advanceOffset(endOffset); // ships + triggers rotation
+
+  // current.jsonl should be gone or empty; an archive segment should exist.
+  const archiveDir = wal._paths.archiveDir;
+  const archived = readdirSync(archiveDir).filter((f) => f.endsWith(".jsonl"));
+  assert.equal(archived.length, 1, "rotation creates one archive segment");
+
+  // Offset reset to 0; next append starts fresh.
+  assert.equal(await wal.readShippedOffset(), 0);
+  await wal.appendLine({ id: 99 });
+  const after = await wal.readBatch();
+  assert.equal(after.rows.length, 1);
+  assert.equal(after.rows[0].id, 99);
+});
+
+test("malformed line is skipped, not blocking the stream", async () => {
+  const { dir, wal } = await fixture();
+  await wal.appendLine({ id: 1 });
+  // Manually append garbage to simulate a torn write from an older build
+  // (current daemon never does this — append is atomic — but defensive).
+  const fs = await import("node:fs/promises");
+  await fs.appendFile(wal._paths.currentPath, "this is not json\n", "utf8");
+  await wal.appendLine({ id: 3 });
+
+  const { rows } = await wal.readBatch();
+  assert.equal(rows.length, 2, "malformed line skipped, valid rows still returned");
+  assert.deepEqual(rows.map((r) => r.id), [1, 3]);
+});
+
+test("row too large is rejected (cap protects O_APPEND atomicity)", async () => {
+  const { wal } = await fixture();
+  const huge = { pad: "x".repeat(5000) }; // > 4000 byte cap
+  await assert.rejects(() => wal.appendLine(huge), /too large/);
+});
+
+test("readBatch returns rows in enqueue order even when disk order is scrambled", async () => {
+  const { dir, wal } = await fixture();
+  // Issue 10 concurrent appends. Each `appendLine` returns a Promise; awaiting
+  // Promise.all serializes the entry points but the underlying fs.appendFile
+  // calls race in the kernel — disk order is non-deterministic.
+  await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+      wal.appendLine({ logical_step: i, payload: `row-${i}` }),
+    ),
+  );
+  const { rows } = await wal.readBatch(20);
+  assert.equal(rows.length, 10);
+  // After our sort fix, the returned order must match the order in which
+  // the appends were initiated (logical_step 0..9).
+  assert.deepEqual(
+    rows.map((r) => r.logical_step),
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    "rows must come back in enqueue order, not disk order",
+  );
+});
+
+test("readBatch strips internal _seq and _enqueuedAt fields before returning", async () => {
+  const { wal } = await fixture();
+  await wal.appendLine({ id: 1, action: "echo" });
+  const { rows } = await wal.readBatch();
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, 1);
+  assert.equal(rows[0].action, "echo");
+  assert.ok(!("_seq" in rows[0]), "_seq must be stripped before shipping");
+  assert.ok(!("_enqueuedAt" in rows[0]), "_enqueuedAt must be stripped before shipping");
+});
+
+test("concurrent appends from many writers do not interleave", async () => {
+  const { dir, wal } = await fixture();
+  const N = 50;
+  const writers = [];
+  for (let i = 0; i < N; i++) {
+    // Each "writer" is a separate wal handle, simulating multiple hooks.
+    const w = createAuditWal({ dataDir: dir });
+    writers.push(w.appendLine({ id: i, action: "concurrent" }));
+  }
+  await Promise.all(writers);
+  const { rows } = await wal.readBatch(N + 5);
+  assert.equal(rows.length, N, "all concurrent appends preserved");
+  const ids = new Set(rows.map((r) => r.id));
+  assert.equal(ids.size, N, "no rows lost or duplicated");
+});
+
+test("pendingBytes shrinks after advanceOffset", async () => {
+  const { wal } = await fixture();
+  assert.equal(await wal.pendingBytes(), 0);
+  await wal.appendLine({ id: 1 });
+  await wal.appendLine({ id: 2 });
+  const before = await wal.pendingBytes();
+  assert.ok(before > 0);
+
+  const { endOffset } = await wal.readBatch();
+  await wal.advanceOffset(endOffset);
+  const after = await wal.pendingBytes();
+  assert.equal(after, 0);
+});
+
+test("pruneArchive keeps newest N segments", async () => {
+  const { dir } = await fixture();
+  const wal = createAuditWal({ dataDir: dir, rotateBytes: 50 });
+
+  // Force several rotations.
+  for (let r = 0; r < 8; r++) {
+    for (let i = 0; i < 3; i++) {
+      await wal.appendLine({ rotation: r, id: i });
+    }
+    const { endOffset } = await wal.readBatch(100);
+    await wal.advanceOffset(endOffset);
+  }
+  const beforePrune = readdirSync(wal._paths.archiveDir).length;
+  assert.ok(beforePrune >= 5);
+
+  await wal.pruneArchive(3);
+  const afterPrune = readdirSync(wal._paths.archiveDir).length;
+  assert.equal(afterPrune, 3, "only the newest 3 segments retained");
+});

--- a/tests/crypto-policy.test.mjs
+++ b/tests/crypto-policy.test.mjs
@@ -35,7 +35,6 @@ test("verifyPolicyDigest returns valid on match", async () => {
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
-    iapEndpoint: "http://localhost:8000",
     timeoutMs: 5000,
     userId: "test",
     agentId: "test",
@@ -52,7 +51,6 @@ test("verifyPolicyDigest returns invalid on mismatch", async () => {
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
-    iapEndpoint: "http://localhost:8000",
     timeoutMs: 5000,
     userId: "test",
     agentId: "test",
@@ -69,7 +67,6 @@ test("verifyPolicyDigest returns invalid when no token digest", async () => {
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
-    iapEndpoint: "http://localhost:8000",
     timeoutMs: 5000
   };
   const service = createCryptoPolicyService(config);
@@ -83,7 +80,6 @@ test("loadCachedState returns null when no state file", async () => {
   const config = {
     dataDir: tmp,
     csrgEndpoint: "http://localhost:8000",
-    iapEndpoint: "http://localhost:8000",
     timeoutMs: 5000
   };
   const service = createCryptoPolicyService(config);

--- a/tests/daemon.test.mjs
+++ b/tests/daemon.test.mjs
@@ -1,0 +1,237 @@
+/**
+ * Phase 4 Tier B daemon tests.
+ *
+ * These spawn the actual daemon as a child process and exercise it through
+ * the daemon-client. Each test uses a unique tmpdir so the socket + PID
+ * file don't collide. Cleanup is in `afterEach`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const daemonScript = path.join(repoRoot, "scripts", "daemon.mjs");
+
+function buildEnv(dataDir) {
+  return {
+    ...process.env,
+    ARMORCLAUDE_DATA_DIR: dataDir,
+    ARMORCLAUDE_RUNTIME_FILE: path.join(dataDir, "runtime.json"),
+    ARMORCLAUDE_POLICY_FILE: path.join(dataDir, "policy.json"),
+    ARMORCLAUDE_DAEMON: "true",
+    ARMORCLAUDE_DEBUG: "false",
+    ARMORCLAUDE_USE_SDK_INTENT: "false",
+    ARMORIQ_API_KEY: "",
+  };
+}
+
+async function spawnDaemonChild(dataDir) {
+  const env = buildEnv(dataDir);
+  const child = spawn(process.execPath, [daemonScript], {
+    detached: true,
+    stdio: "ignore",
+    env,
+    cwd: dataDir,
+  });
+  child.unref();
+  // Poll for socket to appear
+  const socketPath = path.join(dataDir, "daemon.sock");
+  for (let i = 0; i < 30; i++) {
+    if (existsSync(socketPath)) return { child, socketPath };
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error("daemon did not create socket within 3s");
+}
+
+async function killDaemon(child, dataDir) {
+  try { process.kill(child.pid, "SIGTERM"); } catch {}
+  // give it a moment to clean up
+  await new Promise((r) => setTimeout(r, 200));
+  try { process.kill(child.pid, "SIGKILL"); } catch {}
+}
+
+async function loadConfigFor(dataDir) {
+  const env = buildEnv(dataDir);
+  const oldEnv = { ...process.env };
+  Object.assign(process.env, env);
+  // Clear any stale module cache (ESM doesn't really support this so we
+  // just import freshly each time the test loads).
+  const mod = await import(`../scripts/lib/config.mjs?cache=${Date.now()}`);
+  Object.assign(process.env, oldEnv);
+  return mod.loadConfig(env);
+}
+
+test("daemon: ping responds with version + uptime", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-ping-"));
+  const { child } = await spawnDaemonChild(dataDir);
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { pingDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    const reply = await pingDaemon(config);
+    assert.ok(reply, "ping should return a reply");
+    assert.equal(reply.ok, true);
+    assert.ok(typeof reply.version === "string");
+    assert.ok(reply.uptime >= 0);
+  } finally {
+    await killDaemon(child, dataDir);
+  }
+});
+
+test("daemon: PreToolUse roundtrip returns null for fast-path tool", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-pre-"));
+  const { child } = await spawnDaemonChild(dataDir);
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { dispatchViaDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    // 'read' is in the Phase 4 A1 fast-path whitelist — should be allowed
+    // without any plan / token / backend, regardless of intentRequired.
+    const output = await dispatchViaDaemon({
+      event: "PreToolUse",
+      input: {
+        hook_event_name: "PreToolUse",
+        session_id: "sess-daemon-1",
+        tool_name: "read",
+        tool_input: { file_path: "x.txt" },
+      },
+      config,
+    });
+    assert.equal(output, null, `read should fast-path; got ${JSON.stringify(output)}`);
+  } finally {
+    await killDaemon(child, dataDir);
+  }
+});
+
+test("daemon: SessionStart returns context output", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-start-"));
+  const { child } = await spawnDaemonChild(dataDir);
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { dispatchViaDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    const output = await dispatchViaDaemon({
+      event: "SessionStart",
+      input: {
+        hook_event_name: "SessionStart",
+        session_id: "sess-daemon-2",
+        source: "startup",
+      },
+      config,
+    });
+    assert.ok(output?.hookSpecificOutput?.additionalContext);
+    assert.match(
+      output.hookSpecificOutput.additionalContext,
+      /ArmorClaude active/i,
+    );
+  } finally {
+    await killDaemon(child, dataDir);
+  }
+});
+
+test("daemon: roundtrip latency p95 < 50ms (over Unix socket)", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-perf-"));
+  const { child } = await spawnDaemonChild(dataDir);
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { dispatchViaDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    const samples = [];
+    // Warm up — first call sometimes pays connection-establish cost.
+    await dispatchViaDaemon({
+      event: "PreToolUse",
+      input: { hook_event_name: "PreToolUse", session_id: "warm", tool_name: "read", tool_input: {} },
+      config,
+    });
+    for (let i = 0; i < 30; i++) {
+      const start = process.hrtime.bigint();
+      await dispatchViaDaemon({
+        event: "PreToolUse",
+        input: {
+          hook_event_name: "PreToolUse",
+          session_id: "perf-" + i,
+          tool_name: "read",
+          tool_input: { file_path: `f${i}.txt` },
+        },
+        config,
+      });
+      samples.push(Number(process.hrtime.bigint() - start) / 1_000_000);
+    }
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    const p50 = samples[Math.floor(samples.length * 0.5)];
+    assert.ok(
+      p95 < 50,
+      `daemon roundtrip p95 should be < 50ms; got p50=${p50.toFixed(2)} p95=${p95.toFixed(2)}`,
+    );
+  } finally {
+    await killDaemon(child, dataDir);
+  }
+});
+
+test("daemon: concurrent hooks for SAME session serialize (runtime-state stays consistent)", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-conc-"));
+  const { child } = await spawnDaemonChild(dataDir);
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { dispatchViaDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    // Fire SessionStart 10× concurrently for the same session_id.
+    // Per-session lock should serialize them; final runtime.json should
+    // have a single sess-conc-1 entry, not corrupted.
+    const calls = Array.from({ length: 10 }, () =>
+      dispatchViaDaemon({
+        event: "SessionStart",
+        input: {
+          hook_event_name: "SessionStart",
+          session_id: "sess-conc-1",
+          source: "startup",
+        },
+        config,
+      }),
+    );
+    const results = await Promise.all(calls);
+    for (const r of results) {
+      assert.ok(r?.hookSpecificOutput?.additionalContext);
+    }
+    // Read the runtime file directly and assert it's valid JSON with the session present.
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(path.join(dataDir, "runtime.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    assert.ok(parsed.sessions["sess-conc-1"]);
+  } finally {
+    await killDaemon(child, dataDir);
+  }
+});
+
+test("daemon-client: spawnDaemon on missing socket (auto-spawn)", async () => {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "armorclaude-daemon-spawn-"));
+  // Don't pre-spawn — let the client auto-spawn.
+  let childPid;
+  try {
+    const config = await loadConfigFor(dataDir);
+    const { dispatchViaDaemon, pingDaemon } = await import("../scripts/lib/daemon-client.mjs");
+    const output = await dispatchViaDaemon({
+      event: "SessionStart",
+      input: {
+        hook_event_name: "SessionStart",
+        session_id: "sess-spawn-1",
+        source: "startup",
+      },
+      config,
+    });
+    assert.ok(output?.hookSpecificOutput?.additionalContext);
+    // A daemon should now be running. Prove it by ping.
+    const ping = await pingDaemon(config);
+    assert.ok(ping?.ok);
+  } finally {
+    // Kill any daemon that auto-spawned
+    try {
+      const { readFile } = await import("node:fs/promises");
+      const pid = parseInt(await readFile(path.join(dataDir, "daemon.pid"), "utf8"), 10);
+      if (Number.isFinite(pid)) process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+});

--- a/tests/intent.test.mjs
+++ b/tests/intent.test.mjs
@@ -19,8 +19,6 @@ function buildConfig(tmpDir, overrides = {}) {
     runtimeFile: path.join(tmpDir, "runtime.json"),
     useProduction: false,
     backendEndpoint: "http://127.0.0.1:3000",
-    iapEndpoint: "http://127.0.0.1:8000",
-    proxyEndpoint: "http://127.0.0.1:3001",
     csrgEndpoint: "http://127.0.0.1:8000",
     apiKey: "ak_test_12345678",
     useSdkIntent: false,
@@ -179,7 +177,10 @@ test("checkIntentTokenPlan detects expired token", () => {
   assert.match(result.blockReason, /expired/i);
 });
 
-test("checkIntentTokenPlan enforces parameter constraints", () => {
+test("checkIntentTokenPlan: parameter mismatch is advisory by default (Phase 3 hardening)", () => {
+  // Default behavior: metadata.inputs.file_path is a prediction, not a contract.
+  // The user's other Claude Code session showed this fired false-positives when
+  // the LLM couldn't guess exact bash commands. We now allow by default.
   const token = {
     plan: {
       steps: [{ action: "Write", metadata: { inputs: { file_path: "allowed.txt" } } }]
@@ -192,7 +193,27 @@ test("checkIntentTokenPlan enforces parameter constraints", () => {
     toolParams: { file_path: "forbidden.txt" }
   });
   assert.equal(result.matched, true);
-  assert.match(result.blockReason, /parameters not allowed/i);
+  assert.equal(result.blockReason, undefined);
+});
+
+test("checkToolAgainstPlan with strict=true blocks param mismatch (opt-in)", async () => {
+  const { checkToolAgainstPlan } = await import("../scripts/lib/intent.mjs");
+  const plan = {
+    steps: [{ action: "Bash", metadata: { inputs: { command: "npm test" } } }]
+  };
+  const lax = checkToolAgainstPlan({ plan, toolName: "Bash", toolInput: { command: "rm -rf /" } });
+  assert.equal(lax.allowed, true, "default lax mode allows mismatched params");
+  const strict = checkToolAgainstPlan({ plan, toolName: "Bash", toolInput: { command: "rm -rf /" }, strict: true });
+  assert.equal(strict.allowed, false, "strict=true blocks mismatched params");
+  assert.match(strict.reason, /parameters not allowed/i);
+});
+
+test("checkToolAgainstPlan still blocks tool-name drift even when permissive", async () => {
+  const { checkToolAgainstPlan } = await import("../scripts/lib/intent.mjs");
+  const plan = { steps: [{ action: "Read" }] };
+  const r = checkToolAgainstPlan({ plan, toolName: "Bash", toolInput: { command: "x" } });
+  assert.equal(r.allowed, false);
+  assert.match(r.reason, /tool not in plan/i);
 });
 
 test("handlePreToolUse resolves CSRG proofs from token step_proofs across duplicate tools", async () => {

--- a/tests/lifecycle.test.mjs
+++ b/tests/lifecycle.test.mjs
@@ -8,8 +8,11 @@ import {
   handleSessionEnd,
   handleStop,
   handlePostToolUse,
-  handlePostToolUseFailure
+  handlePostToolUseFailure,
+  handlePreToolUse
 } from "../scripts/lib/engine.mjs";
+import { writeFile, mkdir } from "node:fs/promises";
+import { upsertSession, loadRuntimeState, saveRuntimeState, getTrustOps } from "../scripts/lib/runtime-state.mjs";
 
 function buildConfig(tmpDir, overrides = {}) {
   return {
@@ -19,8 +22,6 @@ function buildConfig(tmpDir, overrides = {}) {
     runtimeFile: path.join(tmpDir, "runtime.json"),
     useProduction: false,
     backendEndpoint: "http://127.0.0.1:3000",
-    iapEndpoint: "http://127.0.0.1:8000",
-    proxyEndpoint: "http://127.0.0.1:3001",
     csrgEndpoint: "http://127.0.0.1:8000",
     apiKey: "",
     useSdkIntent: false,
@@ -129,6 +130,14 @@ test("handlePostToolUse sends audit when enabled", async () => {
     { hook_event_name: "SessionStart", session_id: "sess-5" },
     config
   );
+  // Seed an intent token so the audit DTO carries a non-empty `token`. The
+  // PostToolUse handler skips audit when no token is captured (armorclaude#41
+  // — empty token previously crashed conmap-auto's Prisma upsert).
+  {
+    const rs = await loadRuntimeState(config.runtimeFile);
+    upsertSession(rs, "sess-5", { intentTokenRaw: "test.jwt.token", expiresAt: Date.now()/1000 + 600 });
+    await saveRuntimeState(config.runtimeFile, rs);
+  }
 
   const originalFetch = globalThis.fetch;
   let capturedPayload;
@@ -166,6 +175,11 @@ test("handlePostToolUseFailure logs failed status", async () => {
     { hook_event_name: "SessionStart", session_id: "sess-6" },
     config
   );
+  {
+    const rs = await loadRuntimeState(config.runtimeFile);
+    upsertSession(rs, "sess-6", { intentTokenRaw: "test.jwt.token", expiresAt: Date.now()/1000 + 600 });
+    await saveRuntimeState(config.runtimeFile, rs);
+  }
 
   const originalFetch = globalThis.fetch;
   let capturedPayload;
@@ -192,5 +206,340 @@ test("handlePostToolUseFailure logs failed status", async () => {
     assert.equal(capturedPayload.error_message, "Command failed with exit code 1");
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Trust Update integration: auto-reanchor + auto-revoke
+// ---------------------------------------------------------------------------
+
+test("PreToolUse appends ReAnchor trust op when pending plan differs from cached", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-trust-"));
+  // useSdkIntent stays false so the wrapper short-circuits with ok=false.
+  // We're verifying the *integration* — that engine.mjs detected the plan
+  // delta, called reanchorViaSdk, and recorded the op (with ok:false because
+  // the SDK wasn't enabled). That's the exact contract for an audit trail.
+  const config = buildConfig(tmp, { autoReanchor: true, useSdkIntent: false });
+
+  // Seed prior session with a plan + token.
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-trust-1", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_abc", plan: { steps: [] } }),
+    plan: { goal: "g", steps: [{ action: "echo" }] },
+    expiresAt: Math.floor(Date.now() / 1000) + 3600
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  // Stage a new (different) plan via pending-plan.json — same shape the
+  // register_intent_plan MCP tool writes.
+  await writeFile(
+    path.join(tmp, "pending-plan.json"),
+    JSON.stringify({
+      plan: { goal: "g2", steps: [{ action: "echo" }, { action: "add_step" }] },
+      tokenRaw: JSON.stringify({ tokenId: "tok_new", plan: { steps: [] } }),
+      allowedActions: ["echo", "add_step"],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600
+    })
+  );
+
+  await handlePreToolUse(
+    {
+      hook_event_name: "PreToolUse",
+      session_id: "sess-trust-1",
+      tool_name: "echo",
+      tool_input: { text: "hi" }
+    },
+    config
+  );
+
+  const state = await loadRuntimeState(config.runtimeFile);
+  const ops = getTrustOps(state, "sess-trust-1");
+  assert.equal(ops.length, 1, "expected exactly one trust op (ReAnchor)");
+  assert.equal(ops[0].operation, "ReAnchor");
+  assert.ok(ops[0].fromHash, "fromHash should be present");
+  assert.ok(ops[0].toHash, "toHash should be present");
+  assert.notEqual(ops[0].fromHash, ops[0].toHash, "hashes must differ for plan delta");
+  assert.equal(ops[0].ok, false, "ok=false because useSdkIntent disabled");
+});
+
+test("PreToolUse does NOT record ReAnchor when pending plan matches cached", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-trust-nodrift-"));
+  const config = buildConfig(tmp, { autoReanchor: true, useSdkIntent: false });
+
+  const samePlan = { goal: "g", steps: [{ action: "echo" }] };
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-trust-2", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_abc", plan: samePlan }),
+    plan: samePlan,
+    expiresAt: Math.floor(Date.now() / 1000) + 3600
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  await writeFile(
+    path.join(tmp, "pending-plan.json"),
+    JSON.stringify({
+      plan: samePlan,
+      tokenRaw: JSON.stringify({ tokenId: "tok_same" }),
+      allowedActions: ["echo"],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600
+    })
+  );
+
+  await handlePreToolUse(
+    {
+      hook_event_name: "PreToolUse",
+      session_id: "sess-trust-2",
+      tool_name: "echo",
+      tool_input: {}
+    },
+    config
+  );
+
+  const state = await loadRuntimeState(config.runtimeFile);
+  const ops = getTrustOps(state, "sess-trust-2");
+  assert.equal(ops.length, 0, "no plan delta, no trust op");
+});
+
+// Removed 2026-05-13: the autoReanchor flag is gone (always-on). Setting it
+// to false used to skip the reanchor call; now there is no opt-out. The
+// always-on path is already covered by the "PreToolUse triggers auto-reanchor"
+// test above.
+
+test("SessionEnd invokes client.revoke when autoRevokeOnEnd is true", async () => {
+  // We inject a stub directly into the SDK client cache so the test is
+  // independent of the installed @armoriq/sdk version. The wrapper resolves
+  // `getSdkClient(config)` which reads from this cache — pre-populating it
+  // means our stub is called instead of constructing a real ArmorIQClient.
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-trust-revoke-"));
+  const config = buildConfig(tmp, {
+    autoRevokeOnEnd: true,
+    useSdkIntent: true,
+    apiKey: "ak_test_revoke",
+    userId: "test-user-revoke", // unique to dodge cache collisions
+    auditEnabled: false
+  });
+
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-trust-4", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_to_revoke" }),
+    expiresAt: Math.floor(Date.now() / 1000) + 3600
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  const calls = [];
+  const intentMod = await import("../scripts/lib/intent.mjs");
+  // Pre-warm the SDK client cache by calling getSdkClient once and replacing
+  // its revoke implementation. Since getSdkClient caches by a config-derived
+  // key, subsequent lookups inside the wrapper return the same instance.
+  const client = intentMod.getSdkClient(config);
+  const originalRevoke = client.revoke;
+  client.revoke = async (token, reason) => {
+    calls.push({ tokenId: token?.tokenId || token?.token_id, reason });
+    return { trustId: "tr_e2e_revoke" };
+  };
+
+  try {
+    await handleSessionEnd(
+      { hook_event_name: "SessionEnd", session_id: "sess-trust-4" },
+      config
+    );
+  } finally {
+    if (originalRevoke) client.revoke = originalRevoke;
+    else delete client.revoke;
+  }
+
+  assert.equal(calls.length, 1, "client.revoke should fire exactly once on SessionEnd");
+  assert.equal(calls[0].tokenId, "tok_to_revoke");
+  assert.match(calls[0].reason, /session-ended/);
+});
+
+test("SessionEnd does NOT call client.revoke when autoRevokeOnEnd is false", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-trust-norevoke-"));
+  const config = buildConfig(tmp, {
+    autoRevokeOnEnd: false,
+    useSdkIntent: true,
+    apiKey: "ak_test_norevoke",
+    userId: "test-user-norevoke",
+    auditEnabled: false
+  });
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-trust-5", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_no_revoke" }),
+    expiresAt: Math.floor(Date.now() / 1000) + 3600
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  const calls = [];
+  const intentMod = await import("../scripts/lib/intent.mjs");
+  const client = intentMod.getSdkClient(config);
+  const originalRevoke = client.revoke;
+  client.revoke = async () => {
+    calls.push({});
+    return { trustId: "should-not-fire" };
+  };
+
+  try {
+    await handleSessionEnd({ hook_event_name: "SessionEnd", session_id: "sess-trust-5" }, config);
+  } finally {
+    if (originalRevoke) client.revoke = originalRevoke;
+    else delete client.revoke;
+  }
+
+  assert.equal(calls.length, 0, "flag off → revoke must not fire");
+});
+
+
+test("Phase 4 A2: Stop hook proactively refreshes a near-expiry token", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-a2-"));
+  // Setting useSdkIntent: true with a stub injected into the SDK cache so we
+  // can verify requestIntent fires from inside handleStop. apiKey must start
+  // with ak_test_ to pass the SDK's prefix validator.
+  const config = buildConfig(tmp, {
+    intentEndpoint: "",
+    useSdkIntent: true,
+    apiKey: "ak_test_a2",
+    userId: "test-user-a2",
+    refreshThresholdSeconds: 30,
+    validitySeconds: 600
+  });
+
+  // Seed a session with a plan + a token that's ALMOST expired (< 4×30 = 120s).
+  const expiresAt = Math.floor(Date.now() / 1000) + 60; // 60s left
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-a2-1", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_old", plan: { steps: [] } }),
+    plan: { goal: "g", steps: [{ action: "Read" }] },
+    expiresAt,
+    lastPrompt: "test prompt"
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  const calls = [];
+  const intentMod = await import("../scripts/lib/intent.mjs");
+  const client = intentMod.getSdkClient(config);
+  const originalCapture = client.capturePlan;
+  const originalIssue = client.getIntentToken;
+  client.capturePlan = (_llm, _goal, plan) => ({ ok: true, plan });
+  client.getIntentToken = async (planCapture) => {
+    calls.push({ kind: "getIntentToken", plan: planCapture?.plan });
+    return {
+      tokenId: "tok_refreshed",
+      planHash: "h_new",
+      signature: "sig",
+      issuedAt: Date.now() / 1000,
+      expiresAt: Date.now() / 1000 + 600,
+      policy: {},
+      compositeIdentity: "",
+      stepProofs: [],
+      totalSteps: 0,
+      rawToken: { token: { token_id: "tok_refreshed" } }
+    };
+  };
+
+  try {
+    await handleStop(
+      { hook_event_name: "Stop", session_id: "sess-a2-1" },
+      config
+    );
+  } finally {
+    client.capturePlan = originalCapture;
+    if (originalIssue) client.getIntentToken = originalIssue;
+    else delete client.getIntentToken;
+  }
+
+  assert.ok(
+    calls.some((c) => c.kind === "getIntentToken"),
+    "handleStop should pre-refresh the near-expiry token via getIntentToken"
+  );
+});
+
+test("Phase 4 A2: Stop hook does NOT refresh when token is fresh", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-a2-fresh-"));
+  const config = buildConfig(tmp, {
+    useSdkIntent: true,
+    apiKey: "ak_test_a2_fresh",
+    userId: "test-user-a2-fresh",
+    refreshThresholdSeconds: 30,
+    validitySeconds: 600
+  });
+  const expiresAt = Math.floor(Date.now() / 1000) + 600; // 10 min left
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-a2-2", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_fresh" }),
+    plan: { goal: "g", steps: [{ action: "Read" }] },
+    expiresAt
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  const calls = [];
+  const intentMod = await import("../scripts/lib/intent.mjs");
+  const client = intentMod.getSdkClient(config);
+  const originalIssue = client.getIntentToken;
+  client.getIntentToken = async () => {
+    calls.push({ kind: "getIntentToken" });
+    return {};
+  };
+  try {
+    await handleStop({ hook_event_name: "Stop", session_id: "sess-a2-2" }, config);
+  } finally {
+    if (originalIssue) client.getIntentToken = originalIssue;
+    else delete client.getIntentToken;
+  }
+  assert.equal(calls.length, 0, "fresh token must not trigger a refresh");
+});
+
+test("ArmorClaude's own MCP tools are never drift-blocked (deadlock prevention)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-deadlock-"));
+  // Active plan that does NOT include register_intent_plan or any of the
+  // plugin's own tools. Without the whitelist, the plugin would deadlock —
+  // the agent couldn't even call register_intent_plan to escape.
+  // (autoReanchor removed; ignore the field — buildConfig falls back to defaults)
+  const config = buildConfig(tmp, {});
+  const priorState = await loadRuntimeState(config.runtimeFile);
+  upsertSession(priorState, "sess-deadlock-1", {
+    intentTokenRaw: JSON.stringify({ tokenId: "tok_x" }),
+    plan: { goal: "narrow", steps: [{ action: "Read" }] },
+    expiresAt: Math.floor(Date.now() / 1000) + 3600
+  });
+  await saveRuntimeState(config.runtimeFile, priorState);
+
+  const pluginPrefixed = [
+    "mcp__plugin_armorclaude_armorclaude-policy__register_intent_plan",
+    "mcp__plugin_armorclaude_armorclaude-policy__policy_read",
+    "mcp__plugin_armorclaude_armorclaude-policy__policy_update",
+    "mcp__plugin_armorclaude_armorclaude-policy__trust_revoke",
+    "mcp__plugin_armorclaude_armorclaude-policy__trust_reanchor",
+    "mcp__plugin_armorclaude_armorclaude-policy__trust_delegate"
+  ];
+  const directPrefixed = [
+    "mcp__armorclaude-policy__register_intent_plan",
+    "mcp__armorclaude-policy__trust_revoke"
+  ];
+  const baseTools = [
+    "register_intent_plan",
+    "policy_read",
+    "policy_update",
+    "trust_revoke",
+    "trust_reanchor",
+    "trust_delegate"
+  ];
+
+  for (const tool of [...pluginPrefixed, ...directPrefixed, ...baseTools]) {
+    const out = await handlePreToolUse(
+      {
+        hook_event_name: "PreToolUse",
+        session_id: "sess-deadlock-1",
+        tool_name: tool,
+        tool_input: { goal: "x", steps: [{ action: "Bash" }] }
+      },
+      config
+    );
+    // Allow path returns null (no deny output). A deny would set
+    // hookSpecificOutput.permissionDecision = "deny".
+    assert.equal(
+      out,
+      null,
+      `${tool} should pass the whitelist (got: ${JSON.stringify(out)})`
+    );
   }
 });

--- a/tests/perf.test.mjs
+++ b/tests/perf.test.mjs
@@ -1,0 +1,143 @@
+// Phase 4 latency SLAs. These run in-process (no fresh node spawn per
+// invocation), so the numbers here measure ONLY the engine.mjs handler cost
+// — they are a lower bound, not the full per-hook wall-clock. The full hook
+// budget (cold-start + module load + handler) is what Tier B (daemon mode)
+// is designed to eliminate. The SLAs here protect against regressions in
+// the handler itself.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { handlePreToolUse } from "../scripts/lib/engine.mjs";
+
+function buildPerfConfig(tmpDir) {
+  return {
+    mode: "enforce",
+    dataDir: tmpDir,
+    policyFile: path.join(tmpDir, "policy.json"),
+    runtimeFile: path.join(tmpDir, "runtime.json"),
+    useProduction: false,
+    backendEndpoint: "http://127.0.0.1:3000",
+    csrgEndpoint: "http://127.0.0.1:8000",
+    apiKey: "",
+    useSdkIntent: false,
+    intentEndpoint: "",
+    verifyStepEndpoint: "",
+    validitySeconds: 600,
+    refreshThresholdSeconds: 30,
+    timeoutMs: 5000,
+    maxRetries: 1,
+    verifySsl: true,
+    llmId: "claude-code",
+    mcpName: "claude-code",
+    userId: "test-user",
+    agentId: "test-agent",
+    contextId: "default",
+    intentRequired: true,
+    requireCsrgProofs: false,
+    csrgVerifyEnabled: false,
+    policyUpdateEnabled: true,
+    policyUpdateAllowList: ["*"],
+    contextHintsEnabled: true,
+    cryptoPolicyEnabled: false,
+    auditEnabled: false,
+    planningEnabled: false,
+    autoReanchor: false,
+    autoRevokeOnEnd: false,
+    strictParamCheck: false,
+    debug: false,
+    sanitize: { maxChars: 2000, maxDepth: 4, maxKeys: 50, maxItems: 50 }
+  };
+}
+
+async function timed(fn) {
+  const start = process.hrtime.bigint();
+  const result = await fn();
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+  return { elapsedMs, result };
+}
+
+function summarize(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p = (q) => sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))];
+  return { min: sorted[0], p50: p(0.5), p95: p(0.95), max: sorted[sorted.length - 1] };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4 A1 SLA: read-only fast-path tools complete in < 5 ms (in-process).
+// ---------------------------------------------------------------------------
+test("PERF: read-only fast-path tools p95 < 5ms (engine handler only)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-perf-fastpath-"));
+  const config = buildPerfConfig(tmp);
+  const samples = [];
+  for (const tool of ["read", "grep", "glob", "websearch", "webfetch", "exitplanmode", "toolsearch", "todowrite"]) {
+    // 20 iterations per tool to smooth noise
+    for (let i = 0; i < 20; i++) {
+      const { elapsedMs } = await timed(() =>
+        handlePreToolUse(
+          {
+            hook_event_name: "PreToolUse",
+            session_id: "sess-perf",
+            tool_name: tool,
+            tool_input: {}
+          },
+          config
+        )
+      );
+      samples.push(elapsedMs);
+    }
+  }
+  const stats = summarize(samples);
+  assert.ok(
+    stats.p95 < 5,
+    `Read-only fast-path p95 should be < 5 ms; got p50=${stats.p50.toFixed(2)}ms p95=${stats.p95.toFixed(2)}ms max=${stats.max.toFixed(2)}ms`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 A0+full-pipeline SLA: warm path with valid local plan (no backend
+// HTTP) completes in < 100 ms (engine handler only). Today's typical warm
+// path measures ~30-50 ms for engine logic; we set a generous 100 ms ceiling
+// so noisy CI doesn't false-fail.
+// ---------------------------------------------------------------------------
+test("PERF: warm-path Bash with valid plan p95 < 100ms (engine handler only)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-perf-warm-"));
+  const config = buildPerfConfig(tmp);
+  // Seed a session with a plan that includes Bash so drift doesn't fire.
+  await writeFile(
+    config.runtimeFile,
+    JSON.stringify({
+      sessions: {
+        "sess-warm": {
+          plan: { goal: "warm-path test", steps: [{ action: "Bash" }] },
+          allowedActions: ["bash"],
+          lastPrompt: "warm-path test",
+          updatedAt: Math.floor(Date.now() / 1000),
+          startedAt: Math.floor(Date.now() / 1000)
+        }
+      }
+    })
+  );
+  const samples = [];
+  for (let i = 0; i < 50; i++) {
+    const { elapsedMs } = await timed(() =>
+      handlePreToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          session_id: "sess-warm",
+          tool_name: "bash",
+          tool_input: { command: `echo iter-${i}` }
+        },
+        config
+      )
+    );
+    samples.push(elapsedMs);
+  }
+  const stats = summarize(samples);
+  assert.ok(
+    stats.p95 < 100,
+    `Warm-path p95 should be < 100 ms; got p50=${stats.p50.toFixed(2)}ms p95=${stats.p95.toFixed(2)}ms max=${stats.max.toFixed(2)}ms`
+  );
+});

--- a/tests/policy.test.mjs
+++ b/tests/policy.test.mjs
@@ -15,8 +15,7 @@ function buildConfig(tmpDir, overrides = {}) {
     runtimeFile: path.join(tmpDir, "runtime.json"),
     useProduction: false,
     backendEndpoint: "http://127.0.0.1:3000",
-    iapEndpoint: "http://127.0.0.1:8000",
-    proxyEndpoint: "http://127.0.0.1:3001",
+    csrgEndpoint: "http://127.0.0.1:8080",
     apiKey: "",
     useSdkIntent: false,
     intentEndpoint: "",
@@ -115,17 +114,95 @@ test("handlePreToolUse denies when policy blocks tool", async () => {
 test("handlePreToolUse denies missing intent when strict", async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
   const config = buildConfig(tmp, { intentRequired: true });
+  // Use Edit (mutating, NOT in the Phase 4 A1 read-only fast-path) so the
+  // full intent-required pipeline runs. Read/Grep/Glob/WebSearch/etc are
+  // intentionally fast-pathed and bypass this check by design.
   const output = await handlePreToolUse(
     {
       hook_event_name: "PreToolUse",
       session_id: "session-3",
-      tool_name: "read",
-      tool_input: { file_path: "a.txt" }
+      tool_name: "edit",
+      tool_input: { file_path: "a.txt", old_string: "x", new_string: "y" }
     },
     config
   );
   assert.equal(output?.hookSpecificOutput?.permissionDecision, "deny");
   assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /intent plan missing/i);
+});
+
+test("Phase 4 A3: deny output for missing plan includes a register_intent_plan hint", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-a3-missing-"));
+  const config = buildConfig(tmp, { intentRequired: true });
+  const output = await handlePreToolUse(
+    {
+      hook_event_name: "PreToolUse",
+      session_id: "session-a3-1",
+      tool_name: "edit",
+      tool_input: { file_path: "x.txt", old_string: "a", new_string: "b" }
+    },
+    config
+  );
+  const reason = output?.hookSpecificOutput?.permissionDecisionReason || "";
+  assert.equal(output?.hookSpecificOutput?.permissionDecision, "deny");
+  assert.match(reason, /register_intent_plan/, "reason should reference register_intent_plan");
+  assert.match(reason, /```json/, "reason should include a JSON code block");
+  assert.match(reason, /"action":\s*"edit"/, "reason should include the blocked tool in the suggestion");
+});
+
+test("Phase 4 A3: deny on drift extends the existing plan in the hint", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-a3-drift-"));
+  const config = buildConfig(tmp, { intentRequired: true });
+  const { writeFile } = await import("node:fs/promises");
+  // Local-plan-only path (no intentTokenRaw) so the local drift check fires
+  // and returns the actionable hint that extends the cached plan.
+  await writeFile(
+    config.runtimeFile,
+    JSON.stringify({
+      sessions: {
+        "drift-1": {
+          plan: { goal: "the original task", steps: [{ action: "Read" }] },
+          allowedActions: ["read"],
+          lastPrompt: "the original task"
+        }
+      }
+    })
+  );
+  const output = await handlePreToolUse(
+    {
+      hook_event_name: "PreToolUse",
+      session_id: "drift-1",
+      tool_name: "edit",
+      tool_input: { file_path: "y.txt", old_string: "a", new_string: "b" }
+    },
+    config
+  );
+  const reason = output?.hookSpecificOutput?.permissionDecisionReason || "";
+  assert.equal(output?.hookSpecificOutput?.permissionDecision, "deny");
+  assert.match(reason, /register_intent_plan/);
+  // The hint should preserve the existing Read step AND add the new edit step
+  assert.match(reason, /"action":\s*"Read"/);
+  assert.match(reason, /"action":\s*"edit"/);
+});
+
+test("handlePreToolUse fast-paths read-only tools without intent (Phase 4 A1)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-test-"));
+  const config = buildConfig(tmp, { intentRequired: true });
+  for (const tool of ["read", "grep", "glob", "websearch", "webfetch", "exitplanmode"]) {
+    const output = await handlePreToolUse(
+      {
+        hook_event_name: "PreToolUse",
+        session_id: "session-fastpath",
+        tool_name: tool,
+        tool_input: {}
+      },
+      config
+    );
+    assert.equal(
+      output,
+      null,
+      `${tool} should be fast-pathed (no plan check); got ${JSON.stringify(output)}`
+    );
+  }
 });
 
 test("handlePreToolUse allows tool when local plan matches (no backend)", async () => {

--- a/tests/trust-update.test.mjs
+++ b/tests/trust-update.test.mjs
@@ -1,0 +1,240 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  reanchorViaSdk,
+  revokeViaSdk,
+  delegateSubtreeViaSdk
+} from "../scripts/lib/iap-service.mjs";
+import {
+  loadRuntimeState,
+  upsertSession,
+  appendTrustOp,
+  getTrustOps,
+  saveRuntimeState
+} from "../scripts/lib/runtime-state.mjs";
+
+// ---------------------------------------------------------------------------
+// Mock SDK client — matches the shape of @armoriq/sdk's ArmorIQClient just
+// enough for the wrappers under test. Each test injects its own getClient
+// closure so calls and failures can be observed.
+// ---------------------------------------------------------------------------
+
+function mockClient({ revoke, reanchor, delegateSubtree } = {}) {
+  return {
+    revoke: revoke || (async () => ({ trustId: "tr_revoke_default" })),
+    reanchor: reanchor || (async () => ({ trustId: "tr_reanchor_default", delta: { payload: { from_hash: "h1", to_hash: "h2" } } })),
+    delegateSubtree:
+      delegateSubtree ||
+      (async () => ({
+        trustId: "tr_delegate_default",
+        delegationId: "dl_default",
+        inclusionProof: [{ position: "L", sibling_hash: "ab" }],
+        subtreeRoot: "sr_default"
+      }))
+  };
+}
+
+const baseConfig = { apiKey: "ak_test", useSdkIntent: true };
+
+// ---------------------------------------------------------------------------
+// reanchorViaSdk
+// ---------------------------------------------------------------------------
+
+test("reanchorViaSdk forwards token + plan + reason to client.reanchor", async () => {
+  let captured = null;
+  const client = mockClient({
+    reanchor: async (token, plan, reason) => {
+      captured = { token, plan, reason };
+      return { trustId: "tr_42", delta: { payload: { from_hash: "AAA", to_hash: "BBB" } } };
+    }
+  });
+  const result = await reanchorViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    intentToken: { tokenId: "tok_1" },
+    updatedPlan: { goal: "g", steps: [{ action: "x" }] },
+    reason: "plan grew"
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.trustId, "tr_42");
+  assert.equal(result.fromHash, "AAA");
+  assert.equal(result.toHash, "BBB");
+  assert.deepEqual(captured?.plan, { goal: "g", steps: [{ action: "x" }] });
+  assert.equal(captured?.reason, "plan grew");
+});
+
+test("reanchorViaSdk returns ok=false when SDK throws (does not propagate)", async () => {
+  const client = mockClient({
+    reanchor: async () => { throw new Error("iap unreachable"); }
+  });
+  const result = await reanchorViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    intentToken: { tokenId: "x" },
+    updatedPlan: { steps: [] }
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /iap unreachable/);
+});
+
+test("reanchorViaSdk fails fast when SDK is disabled (no apiKey)", async () => {
+  const result = await reanchorViaSdk({
+    getClient: () => mockClient(),
+    config: { useSdkIntent: true }, // no apiKey
+    intentToken: {},
+    updatedPlan: { steps: [] }
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "sdk-disabled");
+});
+
+test("reanchorViaSdk validates required args", async () => {
+  const a = await reanchorViaSdk({ getClient: () => mockClient(), config: baseConfig });
+  assert.equal(a.ok, false);
+  const b = await reanchorViaSdk({
+    getClient: () => mockClient(),
+    config: baseConfig,
+    intentToken: {}
+  });
+  assert.equal(b.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// revokeViaSdk
+// ---------------------------------------------------------------------------
+
+test("revokeViaSdk forwards full intent token + reason + cascade to client.revoke", async () => {
+  let captured = null;
+  const client = mockClient({
+    revoke: async (token, reason, opts) => {
+      captured = { token, reason, opts };
+      return { trustId: "tr_revoke_99", cascadedRevocations: ["child_1"] };
+    }
+  });
+  const result = await revokeViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    intentToken: { tokenId: "parent_token" },
+    reason: "stop",
+    cascade: true
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.trustId, "tr_revoke_99");
+  assert.deepEqual(result.cascadedRevocations, ["child_1"]);
+  assert.equal(captured?.reason, "stop");
+  assert.equal(captured?.opts?.cascade, true);
+});
+
+test("revokeViaSdk synthesizes minimal token when only tokenId is given", async () => {
+  let captured = null;
+  const client = mockClient({
+    revoke: async (token) => {
+      captured = token;
+      return { trustId: "tr_via_id" };
+    }
+  });
+  const result = await revokeViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    tokenId: "tok_only",
+    reason: "operator"
+  });
+  assert.equal(result.ok, true);
+  // The synthesized shape carries token_id deep enough for the backend's
+  // relaxed RevokeDto to extract it.
+  assert.equal(captured?.tokenId, "tok_only");
+  assert.equal(captured?.token_id, "tok_only");
+});
+
+test("revokeViaSdk swallows SDK errors and reports", async () => {
+  const client = mockClient({
+    revoke: async () => { throw new Error("backend 500"); }
+  });
+  const result = await revokeViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    intentToken: { tokenId: "t" },
+    reason: "x"
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /backend 500/);
+});
+
+// ---------------------------------------------------------------------------
+// delegateSubtreeViaSdk
+// ---------------------------------------------------------------------------
+
+test("delegateSubtreeViaSdk forwards subtreePath + delegate key", async () => {
+  let captured = null;
+  const client = mockClient({
+    delegateSubtree: async (token, opts) => {
+      captured = { token, opts };
+      return {
+        trustId: "tr_d_1",
+        delegationId: "dl_1",
+        inclusionProof: [{ position: "R", sibling_hash: "cd" }, { position: "L", sibling_hash: "ef" }],
+        subtreeRoot: "sr_xyz",
+        delegatedToken: { tokenId: "child" }
+      };
+    }
+  });
+  const result = await delegateSubtreeViaSdk({
+    getClient: () => client,
+    config: baseConfig,
+    intentToken: { tokenId: "parent" },
+    opts: { delegatePublicKey: "bobpk", subtreePath: "/steps/[1]", validitySeconds: 600 }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.trustId, "tr_d_1");
+  assert.equal(result.delegationId, "dl_1");
+  assert.equal(captured?.opts?.subtreePath, "/steps/[1]");
+  assert.equal(captured?.opts?.delegatePublicKey, "bobpk");
+  assert.equal(Array.isArray(result.inclusionProof) ? result.inclusionProof.length : 0, 2);
+});
+
+test("delegateSubtreeViaSdk validates required args", async () => {
+  const r = await delegateSubtreeViaSdk({
+    getClient: () => mockClient(),
+    config: baseConfig,
+    intentToken: { tokenId: "p" }
+    // no opts
+  });
+  assert.equal(r.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// runtime-state: appendTrustOp + getTrustOps
+// ---------------------------------------------------------------------------
+
+test("appendTrustOp persists ordered audit entries on the session", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armorclaude-trustop-"));
+  const runtimeFile = path.join(tmp, "runtime.json");
+  const state = await loadRuntimeState(runtimeFile);
+  upsertSession(state, "s1", { intentTokenRaw: "raw" });
+
+  appendTrustOp(state, "s1", { operation: "ReAnchor", trustId: "t1", fromHash: "a", toHash: "b" });
+  appendTrustOp(state, "s1", { operation: "Revoke", trustId: "t2", reason: "stop", ok: true });
+  appendTrustOp(state, "s1", { operation: "Delegate", trustId: "t3", ok: false });
+
+  const ops = getTrustOps(state, "s1");
+  assert.equal(ops.length, 3);
+  assert.deepEqual(ops.map((o) => o.operation), ["ReAnchor", "Revoke", "Delegate"]);
+  assert.equal(ops[0].fromHash, "a");
+  assert.equal(ops[2].ok, false);
+
+  await saveRuntimeState(runtimeFile, state);
+  const reread = await loadRuntimeState(runtimeFile);
+  assert.equal(getTrustOps(reread, "s1").length, 3);
+});
+
+test("appendTrustOp tolerates missing session and missing op", () => {
+  const state = { sessions: {} };
+  appendTrustOp(state, "missing", { operation: "Revoke" }); // should not throw
+  appendTrustOp(state, "", { operation: "Revoke" }); // empty session id
+  appendTrustOp(state, "x", null); // null op
+  assert.equal(getTrustOps(state, "missing").length, 0);
+});


### PR DESCRIPTION
## Summary
- **Audit pipeline**: exclude `mcp__plugin_armorclaude_*` and plumbing tools (ToolSearch, TodoWrite, ListMcpResourcesTool, ReadMcpResourceTool, ExitPlanMode) from PostToolUse audit. Removes 80%+ of audit volume.
- **Pre/Post audit early-exit** on empty intent token so conmap-auto never receives `token=""` rows.
- **`register_intent_plan` MCP**: drops the `useSdkIntent` gate; stamps `CLAUDE_CODE_SESSION_ID` on the pending file → per-session `pending-plan.<sid>.json` so concurrent Claude Code windows don't clobber each other.
- **Pending-plan consume** reads per-session file first, falls back to legacy singleton for back-compat.
- **Auto-reanchor logging**: canonical IAP `planHash` from the token + surface SDK `err.response.status/body` via `debugLog`.
- **`runtime-state` GC**: `POST_EXPIRY_GRACE_SECONDS` purge on save + session-end purge.
- **Daemon mode (always-on)**: `daemon.mjs`, `daemon-client.mjs`, `audit-wal.mjs` — Unix-socket fast path with WAL-backed audit batch. `ARMORCLAUDE_DAEMON` env removed. Hook-router preserves safe in-process fallback.
- **Telemetry**: `daemon-client` logs `connect=Xms total=Yms` per dispatch when `config.debug`. `SOCKET_TIMEOUT_MS` raised 1s → 1.5s for slow first-call handshakes.
- New tests: `daemon.test.mjs`, `audit-wal.test.mjs`, `perf.test.mjs`, `trust-update.test.mjs`.

Closes work on [#35](https://github.com/armoriq/armorClaude/issues/35), [#36](https://github.com/armoriq/armorClaude/issues/36), [#37](https://github.com/armoriq/armorClaude/issues/37), [#38](https://github.com/armoriq/armorClaude/issues/38), [#39](https://github.com/armoriq/armorClaude/issues/39), [#40](https://github.com/armoriq/armorClaude/issues/40), [#41](https://github.com/armoriq/armorClaude/issues/41), [#42](https://github.com/armoriq/armorClaude/issues/42), [#43](https://github.com/armoriq/armorClaude/issues/43). Issues stay open until reviewer marks done.

## Test plan
- [x] `npm test` — 93/93 pass
- [ ] Live: two Claude Code windows register plans → `pending-plan.<sidA>.json` + `pending-plan.<sidB>.json` coexist
- [ ] Live: PostToolUse for `ToolSearch` does NOT emit an audit row
- [ ] Live: auto-reanchor failure logs `status=` and `body=` in debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)