### PR TITLE
fix: post-merge follow-up to Copilot review on #44

### DIFF
--- a/scripts/daemon.mjs
+++ b/scripts/daemon.mjs
@@ -317,12 +317,15 @@ async function handleLine(rawLine, socket) {
       return;
     }
     case "audit_enqueue": {
-      // Fire-and-forget — no reply, the hook client doesn't await. We DO
-      // await enqueueAudit internally so the disk write completes before
-      // the daemon moves on; the client doesn't see this.
-      enqueueAudit(msg.dto).catch((err) => {
+      // Fire-and-forget at the *protocol* level (no reply), but we await
+      // the WAL write so the disk record is durable before the daemon
+      // moves on. Without the await a crash between read and write loses
+      // the audit row even though the WAL exists for exactly this reason.
+      try {
+        await enqueueAudit(msg.dto);
+      } catch (err) {
         if (config.debug) process.stderr.write(`[daemon] enqueueAudit failed: ${err?.message ?? err}\n`);
-      });
+      }
       return;
     }
     case "shutdown": {

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -461,6 +461,24 @@ export async function handlePreToolUse(input, config) {
               priorTokenObj?.planHash ||
               priorTokenObj?.rawToken?.token?.plan_hash ||
               "";
+            // Prefer the canonical planHash from pending.tokenRaw (if a new
+            // token was minted alongside the new plan) so trustOpsLog hashes
+            // stay cross-referencable with backend trust_deltas rows even
+            // when the SDK reanchor call fails. sha256(JSON.stringify(plan))
+            // is a last-resort identifier — different from the CSRG canonical
+            // hash and therefore not auditable against TrustDelta.payload.
+            let canonicalNextHash = "";
+            if (pending.tokenRaw && typeof pending.tokenRaw === "string") {
+              try {
+                const pendingTokenObj = JSON.parse(pending.tokenRaw);
+                canonicalNextHash =
+                  pendingTokenObj?.planHash ||
+                  pendingTokenObj?.rawToken?.token?.plan_hash ||
+                  "";
+              } catch {
+                // ignore — fall through to localNextHash below
+              }
+            }
             const result = await reanchorViaSdk({
               getClient: getSdkClient,
               config,
@@ -472,7 +490,7 @@ export async function handlePreToolUse(input, config) {
               operation: "ReAnchor",
               trustId: result.trustId,
               fromHash: result.fromHash || canonicalPriorHash || localPriorHash,
-              toHash: result.toHash || localNextHash,
+              toHash: result.toHash || canonicalNextHash || localNextHash,
               reason: "plan delta detected at PreToolUse",
               ok: result.ok
             });

--- a/scripts/policy-mcp.mjs
+++ b/scripts/policy-mcp.mjs
@@ -251,6 +251,25 @@ async function run() {
     const config = loadConfig();
     const runtimeState = await loadRuntimeState(config.runtimeFile);
     const sessions = runtimeState.sessions || {};
+
+    // Prefer the current Claude Code window's session id when set. With
+    // multiple concurrent windows the "most-recent updatedAt" heuristic
+    // would route trust_revoke / trust_reanchor / trust_delegate against
+    // the wrong window's token. CLAUDE_CODE_SESSION_ID is stamped on the
+    // per-session pending-plan file (#43) and is reliable here.
+    const envSid = process.env.CLAUDE_CODE_SESSION_ID || "";
+    if (envSid && sessions[envSid]) {
+      return {
+        config,
+        runtimeState,
+        sessionId: envSid,
+        session: sessions[envSid],
+      };
+    }
+
+    // Fallback: pick the most-recently-updated session. Only reached when
+    // the env var is missing (single-window dev) or points at a session
+    // that's been GC'd from runtime.json.
     let chosen = null;
     let chosenId = null;
     for (const [sid, s] of Object.entries(sessions)) {
@@ -294,6 +313,12 @@ async function run() {
         return toTextResult("No active session — nothing to revoke.");
       }
       const intentToken = parseToken(session.intentTokenRaw);
+      if (!intentToken) {
+        return toTextResult(
+          "No parsed intent token on the active session — cannot revoke. " +
+          "Make sure a plan has been registered for this Claude Code session."
+        );
+      }
       const result = await revokeViaSdk({
         getClient: getSdkClient,
         config,

--- a/tests/daemon.test.mjs
+++ b/tests/daemon.test.mjs
@@ -25,7 +25,6 @@ function buildEnv(dataDir) {
     ARMORCLAUDE_DATA_DIR: dataDir,
     ARMORCLAUDE_RUNTIME_FILE: path.join(dataDir, "runtime.json"),
     ARMORCLAUDE_POLICY_FILE: path.join(dataDir, "policy.json"),
-    ARMORCLAUDE_DAEMON: "true",
     ARMORCLAUDE_DEBUG: "false",
     ARMORCLAUDE_USE_SDK_INTENT: "false",
     ARMORIQ_API_KEY: "",


### PR DESCRIPTION
## Summary

Five fixes addressing the Copilot review on the already-merged [PR #44](https://github.com/armoriq/armorClaude/pull/44). The squash-merge happened before these landed, so this is the follow-up.

## Fixes

| # | File | Severity | What |
|---|---|---|---|
| 3 | `scripts/policy-mcp.mjs` | HIGH | `resolveActiveSession()` now honors `CLAUDE_CODE_SESSION_ID` first → multi-window trust ops route to the correct window |
| 4 | `scripts/policy-mcp.mjs` | MED | `trust_revoke` null-checks the parsed intent token before calling `revokeViaSdk` |
| 5 | `scripts/daemon.mjs` | MED | `audit_enqueue` now actually `await`s `enqueueAudit()` — matches the documented durability guarantee |
| 6 | `scripts/lib/engine.mjs` | MED | Auto-reanchor `trustOpsLog` prefers canonical `planHash` from `pending.tokenRaw` before falling back to local sha256 — keeps trustOpsLog cross-referencable with backend `trust_deltas` |
| 7 | `tests/daemon.test.mjs` | LOW | Drop unused `ARMORCLAUDE_DAEMON: \"true\"` (flag was removed in #44; daemon is always-on now) |

## Deliberately skipped from the original review

- **#1 staging URL default in `config.mjs`** — user parked; staging-first stays until a separate prod-cutover branch is ready.
- **#2 `@armoriq/sdk: file:../`** — in-flight on `origin/feat/installer-product-flag-and-prod-sdk`.

## Test plan
- [x] `npm test` — 93/93 pass
- [ ] Multi-window manual smoke: open two Claude Code windows, run `trust_revoke` in window A, verify window A's token gets revoked (not B's)
- [ ] Daemon crash recovery smoke: send `audit_enqueue` then kill -9, verify WAL has the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)