### PR TITLE
chore: sync versions to 0.2.2 + prep v0.2.2 release tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "armorclaude",
       "source": "./",
       "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging.",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
       "homepage": "https://armoriq.ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "description": "ArmorIQ enforcement plugin scaffold for Claude Code",


### PR DESCRIPTION
## Summary

Three version-bearing files declared three different versions after the Phase 10 work. This PR aligns them all on **0.2.2** so the marketplace listing matches what Claude Code actually loads.

| File | Before | After |
|---|---|---|
| `.claude-plugin/plugin.json` | 0.2.2 ✓ | 0.2.2 |
| `.claude-plugin/marketplace.json` | 0.2.0 (stale) | **0.2.2** |
| `package.json` | 0.1.0 (informational; `private: true`) | **0.2.2** |

armorClaude is a Claude Code plugin (not an npm package). The marketplace's `version` field is what listings show to users; the plugin's `version` field is what Claude Code reads when installing. They need to agree.

## After this merges
- Tag `v0.2.2` will be pushed to the merge commit on `main` (publishes the "0.2.2 release" of the plugin).
- Same tag (or `v0.2.2-dev`) on `dev` tip for the dev-flavored variant.

## Test plan
- [x] `npm test` — 93/93 pass (no code change, only metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)