### PR TITLE
chore: sync package-lock.json to 0.2.2 (Copilot follow-up on #49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "armorclaude",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "armorclaude",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "dependencies": {
         "@armoriq/sdk": "^0.3.3",
         "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
## Summary

Copilot flagged on [PR #49](https://github.com/armoriq/armorClaude/pull/49): `package.json` was bumped to 0.2.2 but `package-lock.json` still declared the root package as 0.1.0 at both top-level and `packages[""]`. Next `npm install` would silently rewrite it; this PR makes the lockfile state explicit.

```diff
- "name": "armorclaude",
- "version": "0.1.0",
+ "name": "armorclaude",
+ "version": "0.2.2",
  "lockfileVersion": 3,
```

No code change. `npm install` picked up the new `package.json` version automatically; no dependency churn (0 vulnerabilities).

## Test plan
- [x] `npm install` — clean, 0 vulnerabilities
- [x] lockfile root version + `packages[""].version` both 0.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)