### PR TITLE
feat(marketplace): list both armorclaude (prod) and armorclaude-dev variants

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,16 +7,31 @@
   },
   "metadata": {
     "description": "Official ArmorIQ marketplace for Claude Code security plugins.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "armorclaude",
       "source": "./",
-      "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging.",
+      "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging. Production-hardcoded URLs (api.armoriq.ai + iap.armoriq.ai).",
       "version": "0.2.2",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
+      "homepage": "https://armoriq.ai",
+      "license": "MIT",
+      "author": { "name": "ArmorIQ", "email": "license@armoriq.io" }
+    },
+    {
+      "name": "armorclaude-dev",
+      "source": {
+        "source": "github",
+        "repo": "armoriq/armorClaude",
+        "ref": "dev"
+      },
+      "description": "Intent-based security enforcement for Claude Code — dev variant. Staging/local toggleable via ARMORIQ_ENV (development → 127.0.0.1; default → staging-api.armoriq.ai). Tracks the dev branch HEAD; install only if you're contributing to armorClaude or running a local stack.",
+      "version": "0.2.2",
+      "category": "security",
+      "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp", "dev"],
       "homepage": "https://armoriq.ai",
       "license": "MIT",
       "author": { "name": "ArmorIQ", "email": "license@armoriq.io" }


### PR DESCRIPTION
## Summary

Surface the dev variant alongside the production install via the `armoriq` marketplace, so end-users can pick which branch they want without manual git refs.

## Before

```bash
claude plugin marketplace add armoriq/armorClaude
claude plugin install armorclaude@armoriq          # → main only
```

The dev variant was only reachable via the manually-pushed `v0.2.2-dev` tag, which non-power users don't know about.

## After

```bash
claude plugin marketplace add armoriq/armorClaude

# Production (api.armoriq.ai + iap.armoriq.ai, no env toggle)
claude plugin install armorclaude@armoriq

# Dev variant (staging URLs default, ARMORIQ_ENV=development → 127.0.0.1)
claude plugin install armorclaude-dev@armoriq
```

## Mechanism

Uses Claude Code's documented `source.ref` schema on the marketplace.json plugin source. The dev entry pins to the `dev` branch's HEAD:

```jsonc
{
  "name": "armorclaude-dev",
  "source": {
    "source": "github",
    "repo": "armoriq/armorClaude",
    "ref": "dev"
  },
  ...
}
```

The production entry keeps `"source": "./"` (relative — same branch as the marketplace itself was fetched from, i.e. main).

## Variant differences (recap)

| | `armorclaude` (main) | `armorclaude-dev` (dev) |
|---|---|---|
| Backend URL | `https://api.armoriq.ai` (hardcoded) | derived from `ARMORIQ_ENV` |
| CSRG URL | `https://iap.armoriq.ai` (hardcoded) | derived from `ARMORIQ_ENV` |
| `ARMORIQ_ENV` env var | ignored | `development` → 127.0.0.1; else → staging URLs |
| Tag | `v0.2.2` | `v0.2.2-dev` |
| Use case | end users | contributors / local stack testing |

Plugin UI on both: same single field (API Key). Behavior toggles hardcoded identically.

## Test plan
- [ ] After merge, run `claude plugin marketplace update armoriq` — both entries should appear in `claude plugin list-available`
- [ ] `claude plugin install armorclaude-dev@armoriq` — installs from dev branch tip
- [ ] `claude plugin install armorclaude@armoriq` — installs from main (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)