### PR TITLE
Fix ArmorClaude dev/staging endpoint resolution

### DIFF
--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -14,6 +14,16 @@ function pluginOpt(env, pluginKey, legacyKey) {
   return "";
 }
 
+function normalizeArmoriqEnv(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (["production", "prod"].includes(normalized)) return "production";
+  if (["staging", "stage"].includes(normalized)) return "staging";
+  if (["development", "dev", "local", "test"].includes(normalized)) return "local";
+  return "";
+}
+
 /**
  * armorClaude config — main branch (production).
  *
@@ -21,13 +31,14 @@ function pluginOpt(env, pluginKey, legacyKey) {
  *   env vars                → paths + debug
  *   everything else         → hardcoded to the tested-good default
  *
- * Production-hardcoded. No staging/local switch — `main` ships against
- * api.armoriq.ai + iap.armoriq.ai unconditionally. The dev branch keeps
- * the ARMORIQ_ENV toggle for local development; main is the
- * end-user-facing artifact and must be unambiguously production.
+ * Dev-branch default: staging. Main must keep production-hardcoded behavior
+ * before release, but the dev plugin must never send staging keys to the
+ * production API by accident.
  *
- * Operators who really need a different value can edit this file —
- * scripts/lib/config.mjs IS the config now.
+ * ARMORIQ_ENV:
+ *   staging/default -> staging-api.armoriq.ai + iap-staging.armoriq.ai
+ *   production/prod -> api.armoriq.ai + iap.armoriq.ai
+ *   development/local/test -> local URLs, overridable for local stacks only
  */
 export function loadConfig(env = process.env) {
   // ── Paths ──
@@ -43,14 +54,25 @@ export function loadConfig(env = process.env) {
   // File-based flag avoids shell env var gymnastics on Windows.
   // Delete ~/.armoriq/local-mode to restore production mode.
   const localModeFile = path.join(homedir(), ".armoriq", "local-mode");
-  const localMock = parseBoolean(env.ARMORIQ_LOCAL_MOCK, false) || existsSync(localModeFile);
-  const backendEndpoint = localMock
-    ? env.ARMORIQ_BACKEND_URL?.trim() || "http://localhost:8000"
-    : "https://customer-api.armoriq.ai";
-  const csrgEndpoint = localMock
-    ? env.ARMORIQ_CSRG_URL?.trim() || "http://localhost:8000"
-    : "https://customer-iap.armoriq.ai";
-  const useProduction = !localMock;
+  const requestedEnv = normalizeArmoriqEnv(env.ARMORIQ_ENV) || "staging";
+  const localMock =
+    parseBoolean(env.ARMORIQ_LOCAL_MOCK, false) ||
+    existsSync(localModeFile) ||
+    requestedEnv === "local";
+  const activeEnv = localMock ? "local" : requestedEnv;
+  const backendEndpoint =
+    activeEnv === "local"
+      ? env.ARMORIQ_BACKEND_URL?.trim() || "http://localhost:8000"
+      : activeEnv === "production"
+        ? "https://api.armoriq.ai"
+        : "https://staging-api.armoriq.ai";
+  const csrgEndpoint =
+    activeEnv === "local"
+      ? env.ARMORIQ_CSRG_URL?.trim() || "http://localhost:8000"
+      : activeEnv === "production"
+        ? "https://iap.armoriq.ai"
+        : "https://iap-staging.armoriq.ai";
+  const useProduction = activeEnv === "production";
 
   // ── The one userConfig field: api_key. UI primary, legacy env fallback. ──
   let apiKey = pluginOpt(env, "API_KEY", "ARMORIQ_API_KEY");
@@ -70,6 +92,7 @@ export function loadConfig(env = process.env) {
     dataDir,
     policyFile,
     runtimeFile,
+    armoriqEnv: activeEnv,
     useProduction,
     backendEndpoint,
     csrgEndpoint,

--- a/tests/crypto-integrity.test.mjs
+++ b/tests/crypto-integrity.test.mjs
@@ -92,6 +92,45 @@ test("loadConfig: cryptoPolicyEnabled is tied to apiKey presence", () => {
   assert.equal(config.cryptoPolicyEnabled, Boolean(config.apiKey));
 });
 
+test("loadConfig: dev branch defaults to staging endpoints", () => {
+  const config = loadConfig({});
+  assert.equal(config.armoriqEnv, "staging");
+  assert.equal(config.useProduction, false);
+  assert.equal(config.backendEndpoint, "https://staging-api.armoriq.ai");
+  assert.equal(config.csrgEndpoint, "https://iap-staging.armoriq.ai");
+});
+
+test("loadConfig: ARMORIQ_ENV=staging uses only staging endpoints", () => {
+  const config = loadConfig({
+    ARMORIQ_ENV: "staging",
+    ARMORIQ_BACKEND_URL: "https://example.invalid",
+    ARMORIQ_CSRG_URL: "https://example.invalid"
+  });
+  assert.equal(config.armoriqEnv, "staging");
+  assert.equal(config.backendEndpoint, "https://staging-api.armoriq.ai");
+  assert.equal(config.csrgEndpoint, "https://iap-staging.armoriq.ai");
+});
+
+test("loadConfig: ARMORIQ_ENV=production uses production endpoints", () => {
+  const config = loadConfig({ ARMORIQ_ENV: "production" });
+  assert.equal(config.armoriqEnv, "production");
+  assert.equal(config.useProduction, true);
+  assert.equal(config.backendEndpoint, "https://api.armoriq.ai");
+  assert.equal(config.csrgEndpoint, "https://iap.armoriq.ai");
+});
+
+test("loadConfig: ARMORIQ_ENV=development allows local endpoint overrides", () => {
+  const config = loadConfig({
+    ARMORIQ_ENV: "development",
+    ARMORIQ_BACKEND_URL: "http://127.0.0.1:3000",
+    ARMORIQ_CSRG_URL: "http://127.0.0.1:8080"
+  });
+  assert.equal(config.armoriqEnv, "local");
+  assert.equal(config.useProduction, false);
+  assert.equal(config.backendEndpoint, "http://127.0.0.1:3000");
+  assert.equal(config.csrgEndpoint, "http://127.0.0.1:8080");
+});
+
 // ---------------------------------------------------------------------------
 // /armor policy confirm with crypto enabled
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Default ArmorClaude dev config to staging endpoints instead of production/customer endpoints
- Add explicit ARMORIQ_ENV handling for staging, production, and local development
- Add regression tests for staging, production, and local endpoint resolution

## Verification
- node --test tests/crypto-integrity.test.mjs
- npm test (275/275 passing)
- Masked live smoke test issued an intent token against staging with current key

## Notes
- This PR does not change installer or SDK package selection; those were audited separately and should be handled in a follow-up PR.
