### PR TITLE
fix: use @armoriq/sdk-dev on dev branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "armorclaude",
       "version": "0.2.2",
       "dependencies": {
-        "@armoriq/sdk": "^0.3.3",
+        "@armoriq/sdk-dev": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^3.25.76"
       },
@@ -22,17 +22,17 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@armoriq/sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.3.3.tgz",
-      "integrity": "sha512-OSBY09wPAHU/8ZESkjC8cUCthbkKId2nSXUVrD2WpZYglpXRxOEnoxS//3CMeVWanXr5nupwsqih5IdgXnfgDQ==",
+    "node_modules/@armoriq/sdk-dev": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@armoriq/sdk-dev/-/sdk-dev-0.3.7.tgz",
+      "integrity": "sha512-wZsItPuazUFj6k7GZzNm3R/R1+1nxZpbayznb8OwkeJnZVg1ROYksBWzdXz9mYD86NqUOcD7AzhKvIriLKNRcg==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",
         "js-yaml": "^4.1.1"
       },
       "bin": {
-        "armoriq": "dist/cli/index.js"
+        "armoriq-dev": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
-    "@armoriq/sdk": "^0.3.3",
+    "@armoriq/sdk-dev": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   },

--- a/scripts/lib/intent.mjs
+++ b/scripts/lib/intent.mjs
@@ -1,4 +1,4 @@
-import armoriqSdk from "@armoriq/sdk";
+import armoriqSdk from "@armoriq/sdk-dev";
 import {
   isPlainObject,
   isSubsetValue,


### PR DESCRIPTION
## Summary
- Swap `@armoriq/sdk` → `@armoriq/sdk-dev` in package.json (^0.3.7)
- Update import in `scripts/lib/intent.mjs` to match
- Dev branch should consume the dev-track SDK so staging endpoints, credential paths, and feature flags stay in sync with the dev plugin

## Test plan
- [ ] `npm install` resolves `@armoriq/sdk-dev` cleanly
- [ ] `npm test` passes
- [ ] Dev plugin still connects to staging backend via the sdk-dev client

🤖 Generated with [Claude Code](https://claude.com/claude-code)