### PR TITLE
fix: bump @armoriq/sdk to ^0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "armorclaude",
       "version": "0.2.2",
       "dependencies": {
-        "@armoriq/sdk": "^0.3.3",
+        "@armoriq/sdk": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^3.25.76"
       },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@armoriq/sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.3.3.tgz",
-      "integrity": "sha512-OSBY09wPAHU/8ZESkjC8cUCthbkKId2nSXUVrD2WpZYglpXRxOEnoxS//3CMeVWanXr5nupwsqih5IdgXnfgDQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-CVNqsZ47FyXSB98/tjzo/LmUjisPQpJiid/kbwLK4KrTYLlAx/XBEOC4sFsLbAYXXubSLuYaUJi8njxNld4WKA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
-    "@armoriq/sdk": "^0.3.3",
+    "@armoriq/sdk": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   },


### PR DESCRIPTION
## Summary
- Bump `@armoriq/sdk` from `^0.3.3` to `^0.3.7` on main/prod branch
- Aligns with latest published SDK version

## Test plan
- [ ] `npm install` resolves cleanly
- [ ] `npm test` passes
- [ ] Prod plugin still works with updated SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)