### PR TITLE
fix: bootstrap --ignore-scripts for plugin install

### DIFF
--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -34,7 +34,7 @@ if (!installedOk()) {
   process.stderr.write("[armorclaude] installing dependencies (one-time)...\n");
   const result = spawnSync(
     "npm",
-    ["install", "--omit=dev", "--silent", "--no-audit", "--no-fund"],
+    ["install", "--omit=dev", "--ignore-scripts", "--silent", "--no-audit", "--no-fund"],
     {
       cwd: pluginRoot,
       stdio: ["ignore", "ignore", "inherit"],


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to the `npm install` in `scripts/bootstrap.mjs`
- The `prepare` script runs `husky`, which is a devDependency — not present during `--omit=dev` installs, causing the SessionStart hook to fail on every fresh plugin install

## Root cause
`npm install --omit=dev` skips devDependencies but still runs lifecycle scripts. The `prepare: "husky"` script crashes with exit 127 (command not found), which bootstrap.mjs treats as a fatal error → plugin fails to start.

## Test plan
- [ ] Fresh `claude plugin install armorclaude@armoriq` → no SessionStart error
- [ ] Plugin hooks fire normally after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)