### PR TITLE
fix: bootstrap --ignore-scripts + sdk-dev path

### DIFF
--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -10,7 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.dirname(__dirname);
 const installedMarker = path.join(pluginRoot, "node_modules", ".armorclaude-installed");
 const packageFiles = [
-  path.join(pluginRoot, "node_modules", "@armoriq", "sdk", "package.json"),
+  path.join(pluginRoot, "node_modules", "@armoriq", "sdk-dev", "package.json"),
   path.join(pluginRoot, "node_modules", "zod", "package.json"),
   path.join(pluginRoot, "node_modules", "@modelcontextprotocol", "sdk", "package.json"),
 ];
@@ -34,7 +34,7 @@ if (!installedOk()) {
   process.stderr.write("[armorclaude] installing dependencies (one-time)...\n");
   const result = spawnSync(
     "npm",
-    ["install", "--omit=dev", "--silent", "--no-audit", "--no-fund"],
+    ["install", "--omit=dev", "--ignore-scripts", "--silent", "--no-audit", "--no-fund"],
     {
       cwd: pluginRoot,
       stdio: ["ignore", "ignore", "inherit"],


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to bootstrap `npm install` (same husky fix as main)
- Fix `packageFiles` check: `@armoriq/sdk` → `@armoriq/sdk-dev` to match the dependency swap from PR #57 — otherwise `installedOk()` always returns false and npm reinstalls every session start

## Test plan
- [ ] Fresh `claude plugin install armorclaude-dev@armoriq` → no SessionStart error
- [ ] Second session start doesn't re-run npm install (marker check passes)
- [ ] Plugin hooks fire normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)