### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "armorclaude",
       "source": "./",
       "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging. Production-hardcoded URLs (api.armoriq.ai + iap.armoriq.ai).",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
       "homepage": "https://armoriq.ai",
@@ -29,7 +29,7 @@
         "ref": "dev"
       },
       "description": "Intent-based security enforcement for Claude Code — dev variant. Staging/local toggleable via ARMORIQ_ENV (development → 127.0.0.1; default → staging-api.armoriq.ai). Tracks the dev branch HEAD; install only if you're contributing to armorClaude or running a local stack.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp", "dev"],
       "homepage": "https://armoriq.ai",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ArmorIQ intent-based security enforcement for Claude Code: policy-based tool access control, intent verification, CSRG cryptographic proofs, and audit logging.",
   "author": { "name": "ArmorIQ", "email": "license@armoriq.io" },
   "homepage": "https://armoriq.ai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "armorclaude",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "armorclaude",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@armoriq/sdk": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "description": "ArmorIQ enforcement plugin scaffold for Claude Code",


### PR DESCRIPTION
## Summary
- Bump version `0.2.2` → `0.2.3` in `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`
- Without a version bump, `claude plugin update` thinks it's already up to date and doesn't pull the bootstrap fix from PR #59

## Test plan
- [ ] After merge: `claude plugin update armorclaude` → pulls 0.2.3
- [ ] SessionStart hook no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)