### PR TITLE
fix: default ARMORIQ_ENV to production on main branch

### DIFF
--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -36,8 +36,8 @@ function normalizeArmoriqEnv(value) {
  * production API by accident.
  *
  * ARMORIQ_ENV:
- *   staging/default -> staging-api.armoriq.ai + iap-staging.armoriq.ai
- *   production/prod -> api.armoriq.ai + iap.armoriq.ai
+ *   production/default -> api.armoriq.ai + iap.armoriq.ai
+ *   staging/stage -> staging-api.armoriq.ai + iap-staging.armoriq.ai
  *   development/local/test -> local URLs, overridable for local stacks only
  */
 export function loadConfig(env = process.env) {
@@ -54,7 +54,7 @@ export function loadConfig(env = process.env) {
   // File-based flag avoids shell env var gymnastics on Windows.
   // Delete ~/.armoriq/local-mode to restore production mode.
   const localModeFile = path.join(homedir(), ".armoriq", "local-mode");
-  const requestedEnv = normalizeArmoriqEnv(env.ARMORIQ_ENV) || "staging";
+  const requestedEnv = normalizeArmoriqEnv(env.ARMORIQ_ENV) || "production";
   const localMock =
     parseBoolean(env.ARMORIQ_LOCAL_MOCK, false) ||
     existsSync(localModeFile) ||


### PR DESCRIPTION
## Summary
- Change default `ARMORIQ_ENV` fallback from `"staging"` to `"production"` on main branch
- **This is why no plans appear in the prod dashboard** — the prod plugin was silently sending everything to `staging-api.armoriq.ai`

## Root cause
`config.mjs:57`: `const requestedEnv = normalizeArmoriqEnv(env.ARMORIQ_ENV) || "staging"`

End users don't set `ARMORIQ_ENV`, so it falls through to the default. On main that default must be `"production"` — the dev branch correctly defaults to `"staging"`.

## Test plan
- [ ] Restart Claude Code with prod plugin → intents register against `api.armoriq.ai`
- [ ] New plans appear in the ArmorIQ prod dashboard under the org

🤖 Generated with [Claude Code](https://claude.com/claude-code)