### PR TITLE
chore: add MIT LICENSE and tighten package.json metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ArmorIQ Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.4",
   "private": true,
   "type": "module",
-  "description": "ArmorIQ enforcement plugin scaffold for Claude Code",
+  "description": "ArmorIQ intent-based security enforcement for Claude Code",
+  "license": "MIT",
   "scripts": {
     "test": "node --test",
     "check": "node --test",


### PR DESCRIPTION
## Summary

Prereqs for the third-party registry submission effort tracked in #65.

- Adds `LICENSE` (MIT) at repo root — GitHub previously reported `licenseInfo: null` and several curated registries (awesome-claude-code etc) require explicit licensing
- Adds `"license": "MIT"` field to `package.json`
- Tightens `package.json` description from "ArmorIQ enforcement plugin scaffold for Claude Code" to "ArmorIQ intent-based security enforcement for Claude Code"

## Follow-up (post-merge, manual)

Set the GitHub repo description via web UI or `gh repo edit`:
```
gh repo edit armoriq/armorClaude --description "Intent-based security plugin for Claude Code - registers a plan per prompt and enforces policy on every tool call via hooks."
```

Refs #66 Refs #65

## Test plan
- [x] LICENSE present at repo root
- [x] package.json license field set
- [ ] After merge: `gh api repos/armoriq/armorClaude --jq .license` returns MIT
- [ ] Repo description visible on github.com page

🤖 Generated with [Claude Code](https://claude.com/claude-code)