### PR TITLE
fix(plugin-manifests): point homepage at armoriq.ai/tools/armorclaude

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
       "version": "0.2.4",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
-      "homepage": "https://armoriq.ai",
+      "homepage": "https://armoriq.ai/tools/armorclaude",
       "license": "MIT",
       "author": { "name": "ArmorIQ", "email": "license@armoriq.io" }
     },
@@ -32,7 +32,7 @@
       "version": "0.2.4",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp", "dev"],
-      "homepage": "https://armoriq.ai",
+      "homepage": "https://armoriq.ai/tools/armorclaude",
       "license": "MIT",
       "author": { "name": "ArmorIQ", "email": "license@armoriq.io" }
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.2.4",
   "description": "ArmorIQ intent-based security enforcement for Claude Code: policy-based tool access control, intent verification, CSRG cryptographic proofs, and audit logging.",
   "author": { "name": "ArmorIQ", "email": "license@armoriq.io" },
-  "homepage": "https://armoriq.ai",
+  "homepage": "https://armoriq.ai/tools/armorclaude",
   "repository": "https://github.com/armoriq/armorClaude",
   "license": "MIT",
   "keywords": ["security", "policy", "audit", "intent", "armoriq", "mcp"],


### PR DESCRIPTION
## Summary

Corrects the `homepage` URL in both plugin manifests to point at the canonical product page `https://armoriq.ai/tools/armorclaude`.

## Why

ArmorClaude is live in the Anthropic community marketplace ([`anthropics/claude-plugins-community/.claude-plugin/marketplace.json`](https://github.com/anthropics/claude-plugins-community/blob/main/.claude-plugin/marketplace.json)) but the listed homepage is wrong:

| Source | Current value |
|---|---|
| Anthropic community catalog | `https://armorclaude-docs.armoriq.ai` |
| `.claude-plugin/plugin.json` (this repo) | `https://armoriq.ai` |
| `.claude-plugin/marketplace.json` (this repo, both entries) | `https://armoriq.ai` |
| **Canonical product page** | **`https://armoriq.ai/tools/armorclaude`** |

Three sources of truth, none matching what should be the user-facing page.

## Files touched

- `.claude-plugin/plugin.json` -- homepage updated to canonical URL
- `.claude-plugin/marketplace.json` -- both `armorclaude` and `armorclaude-dev` entry homepage fields updated

## Expected behaviour after merge

- Repo manifests now match the canonical URL
- Anthropic catalog syncs SHA-pinned from this repo nightly; tomorrow's sync should bump our pinned SHA and refresh the homepage if Anthropic pulls from `plugin.json`/`marketplace.json`
- If the catalog still shows the stale `armorclaude-docs.armoriq.ai` URL 24h after merge, escalate by editing the Console submission at https://platform.claude.com/plugins

Refs #68 Refs #65

## Test plan
- [x] curl https://armoriq.ai/tools/armorclaude returns HTTP 200
- [ ] After merge: verify Anthropic community catalog SHA bumps to this commit on next nightly sync
- [ ] After merge: verify catalog `homepage` field updates (if Anthropic pulls from manifest)
- [ ] If not auto-updated: edit Console submission directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)