### PR TITLE
Soften /armor command UX: tag handled responses instead of bare "bloc…

### DIFF
--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -1,5 +1,5 @@
 import { isPlainObject, normalizeToolName, nowEpochSeconds, redactSecrets, sanitizeParams } from "./common.mjs";
-import { addPromptContext, askPreTool, blockPrompt, denyPreTool, denyPreToolWithHint } from "./hook-output.mjs";
+import { addPromptContext, armorReply, askPreTool, blockPrompt, denyPreTool, denyPreToolWithHint } from "./hook-output.mjs";
 import { isArmorPolicyCommand, handleArmorPolicyCommand } from "./armor-policy-commands.mjs";
 import { getTemplateNames } from "./policy-templates.mjs";
 import {
@@ -376,7 +376,7 @@ export async function handleUserPromptExpansion(input, config) {
   const prompt = typeof input?.prompt === "string" ? input.prompt.trim() : "";
   if (isArmorPolicyCommand(prompt)) {
     const response = await handleArmorPolicyCommand(prompt, config);
-    return blockPrompt(response);
+    return armorReply(response);
   }
 
   const commandName = typeof input?.command_name === "string" ? input.command_name.trim() : "";
@@ -384,7 +384,7 @@ export async function handleUserPromptExpansion(input, config) {
   const normalizedCommand = commandName.toLowerCase().replace(/^\/+/, "");
   if (["armor", "armorclaude:armor"].includes(normalizedCommand)) {
     const response = await handleArmorPolicyCommand(`/armor ${commandArgs}`.trim(), config);
-    return blockPrompt(response);
+    return armorReply(response);
   }
   if (["armor-policy", "armorclaude:armor-policy"].includes(normalizedCommand)) {
     return blockPrompt(legacyArmorPolicyMessage());
@@ -407,7 +407,7 @@ export async function handleUserPromptSubmit(input, config) {
   // --- /armor commands: human-only, policy-immune ---
   if (isArmorPolicyCommand(prompt)) {
     const response = await handleArmorPolicyCommand(prompt, config);
-    return blockPrompt(response);
+    return armorReply(response);
   }
   if (/^\s*\/(?:armor-policy|armorclaude:armor-policy)\b/i.test(prompt)) {
     return blockPrompt(legacyArmorPolicyMessage());

--- a/scripts/lib/hook-output.mjs
+++ b/scripts/lib/hook-output.mjs
@@ -78,6 +78,20 @@ export function blockPrompt(reason) {
   };
 }
 
+/**
+ * Reply to a handled `/armor` slash command.
+ *
+ * Mechanically this is still a `block` decision — that's the only hook output
+ * that keeps the command text away from the LLM while showing our own output.
+ * Claude Code's UI prints a fixed "operation blocked by hook:" prefix for any
+ * block, which reads as an error even though the command succeeded. We can't
+ * suppress that prefix, but we can lead the reason with a subtle tag so the
+ * message reads as a normal, handled command rather than a failure.
+ */
+export function armorReply(reason) {
+  return blockPrompt(`(ArmorClaude — handled OK)\n${reason}`);
+}
+
 export function addPromptContext(context, hookEventName = "UserPromptSubmit") {
   return {
     hookSpecificOutput: {


### PR DESCRIPTION
…ked"

/armor slash commands are intercepted with a block decision so the command text never reaches the LLM. Claude Code renders that as "operation blocked by hook:", which reads as an error even though the command actually succeeded.

Add an armorReply() helper that leads genuine command responses with a subtle "(ArmorClaude — handled OK)" tag, and use it at the real command sites in engine.mjs. Legacy /armor-policy deprecation redirects keep the plain block. The harness prefix itself can't be changed from a plugin; this just makes the body read as handled rather than failed.