### PR TITLE
Fix within_workspace policy check; explain approval prompts

### DIFF
--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -214,7 +214,7 @@ function policyDecisionRequiresApproval(policyDecision) {
   return action === "require_approval" || effect === "require_approval";
 }
 
-async function evaluateConfiguredPolicy(config, policyState, toolName, toolInput) {
+async function evaluateConfiguredPolicy(config, policyState, toolName, toolInput, workspaceRoot) {
   if (config.enforcementEngine === "opa" && config.opaPdpUrl) {
     const opaInput = compileToOpaInput(policyState.policy, toolName, toolInput);
     return await evaluateOpa(config, opaInput);
@@ -222,8 +222,21 @@ async function evaluateConfiguredPolicy(config, policyState, toolName, toolInput
   return evaluatePolicy({
     policy: policyState.policy,
     toolName,
-    toolParams: toolInput
+    toolParams: toolInput,
+    workspaceRoot
   });
+}
+
+// Determine the workspace root for path-scoped policy conditions
+// (e.g. within_workspace). Prefer the explicit project dir from the hook
+// payload / Claude Code env over process.cwd(), because the long-lived daemon
+// runs with cwd set to the plugin data dir, not the user's project.
+function resolveWorkspaceRoot(input) {
+  const fromEnv = typeof process.env.CLAUDE_PROJECT_DIR === "string"
+    ? process.env.CLAUDE_PROJECT_DIR.trim()
+    : "";
+  const fromInput = input && typeof input.cwd === "string" ? input.cwd.trim() : "";
+  return fromEnv || fromInput || "";
 }
 
 function preToolPolicyOutput(policyDecision, toolName) {
@@ -568,7 +581,7 @@ export async function handlePreToolUse(input, config) {
   ]);
   if (readOnlyPolicyTools.has(norm)) {
     const safePolicyState = await loadPolicyState(config.policyFile);
-    const safePolicyDecision = await evaluateConfiguredPolicy(config, safePolicyState, toolName, toolInput);
+    const safePolicyDecision = await evaluateConfiguredPolicy(config, safePolicyState, toolName, toolInput, resolveWorkspaceRoot(input));
     const safePolicyOutput = preToolPolicyOutput(safePolicyDecision, toolName);
     if (safePolicyOutput) return safePolicyOutput;
     return null;
@@ -729,7 +742,7 @@ export async function handlePreToolUse(input, config) {
   }
 
   // --- Policy evaluation: dispatch based on enforcement engine ---
-  let policyDecision = await evaluateConfiguredPolicy(config, policyState, toolName, toolInput);
+  let policyDecision = await evaluateConfiguredPolicy(config, policyState, toolName, toolInput, resolveWorkspaceRoot(input));
   const requiresUserApproval = policyDecisionRequiresApproval(policyDecision);
   if (!policyDecision.allowed && !requiresUserApproval) {
     return denyPreTool(policyDecision.reason || "ArmorClaude policy denied");

--- a/scripts/lib/policy-ir.mjs
+++ b/scripts/lib/policy-ir.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 import { isPlainObject, normalizeToolName } from "./common.mjs";
 
 export const POLICY_IR_VERSION = "armor.policy.v1";
@@ -465,7 +466,23 @@ function conditionValue(field, toolName, toolParams = {}) {
   return undefined;
 }
 
-function conditionMatches(condition, toolName, toolParams) {
+// Resolve a file path against the workspace root and report whether it lands
+// inside that root. Both relative and absolute paths are handled: relative
+// paths are resolved against the root, absolute paths are compared directly.
+// If the workspace root is unknown we return false (treat as "outside"), which
+// is the fail-safe answer — an out-of-workspace write should require approval
+// rather than be silently permitted.
+function pathWithinWorkspace(filePath, workspaceRoot) {
+  if (typeof filePath !== "string" || !filePath) return false;
+  if (typeof workspaceRoot !== "string" || !workspaceRoot) return false;
+  const root = path.resolve(workspaceRoot);
+  const resolved = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(root, filePath);
+  return resolved === root || resolved.startsWith(root + path.sep);
+}
+
+function conditionMatches(condition, toolName, toolParams, context = {}) {
   const actual = conditionValue(condition.field, toolName, toolParams);
   const expected = condition.value;
   switch (condition.op) {
@@ -475,26 +492,85 @@ function conditionMatches(condition, toolName, toolParams) {
     case "matches": return typeof expected === "string" && new RegExp(expected).test(String(actual));
     case "not_matches": return typeof expected === "string" && !new RegExp(expected).test(String(actual));
     case "starts_with": return typeof expected === "string" && String(actual).startsWith(expected);
-    case "within_workspace": return typeof actual === "string" && !actual.startsWith("/") && !actual.includes("..");
+    case "within_workspace": {
+      // `value: true`  → condition matches when the path IS inside the workspace
+      // `value: false` → condition matches when the path is OUTSIDE the workspace
+      // Default to requiring "inside" when no explicit value is given.
+      const want = expected === false ? false : true;
+      return pathWithinWorkspace(actual, context.workspaceRoot) === want;
+    }
     default: return false;
   }
 }
 
-function statementMatches(statement, toolName, toolParams) {
+function statementMatches(statement, toolName, toolParams, context) {
   if (!selectorMatches(statement.action, toolName)) return false;
-  return statement.conditions.every((condition) => conditionMatches(condition, toolName, toolParams));
+  return statement.conditions.every((condition) => conditionMatches(condition, toolName, toolParams, context));
 }
 
-export function evaluatePolicyIr({ policy, toolName, toolParams }) {
+// Registry of plain-language explainers for policy conditions, so an approval
+// prompt can tell the user *why* it is asking rather than just citing a rule
+// id. Each describer receives (condition, actual, ctx) and returns a clause, or
+// a falsy value to fall through. Keys are matched most-specific first:
+//   1. "<field>:<op>"  (e.g. "file.path:within_workspace")
+//   2. "<field>"       (e.g. "bash.program")
+// Add a new explanation by adding an entry here, or at runtime via
+// registerConditionDescriber() — no need to touch the approval flow itself.
+const CONDITION_DESCRIBERS = {
+  "file.path:within_workspace": (condition, actual) =>
+    condition.value === false
+      ? `it writes to a path outside the workspace (${actual || "unknown path"})`
+      : `it writes inside the workspace (${actual || "unknown path"})`,
+  "file.path": (condition, actual) => `the file path is "${actual}"`,
+  "bash.program": (condition, actual) => `it runs "${actual}"`,
+  "bash.raw": (condition) => `the command matches a guarded pattern (${condition.value})`,
+  "network.host": (condition, actual) => `it contacts host "${actual}"`,
+};
+
+// Register (or override) a condition describer. `key` is "<field>" or
+// "<field>:<op>". Lets other modules extend approval messaging without editing
+// this file.
+export function registerConditionDescriber(key, describer) {
+  if (typeof key === "string" && typeof describer === "function") {
+    CONDITION_DESCRIBERS[key] = describer;
+  }
+}
+
+// Render a single matched condition as a plain-language clause via the registry,
+// falling back to a generic "<field> <op>" description.
+function describeCondition(condition, toolName, toolParams) {
+  const actual = conditionValue(condition.field, toolName, toolParams);
+  const describer =
+    CONDITION_DESCRIBERS[`${condition.field}:${condition.op}`] ||
+    CONDITION_DESCRIBERS[condition.field];
+  if (describer) {
+    const text = describer(condition, actual, { toolName, toolParams });
+    if (text) return text;
+  }
+  return `${condition.field} ${condition.op}`;
+}
+
+// Build the human-readable reason shown when a statement requires approval.
+function explainApproval(statement, toolName, toolParams) {
+  const tool = toolName || "this tool";
+  const clauses = (statement.conditions || [])
+    .map((condition) => describeCondition(condition, toolName, toolParams))
+    .filter(Boolean);
+  const why = clauses.length ? ` because ${clauses.join(" and ")}` : "";
+  return `ArmorClaude needs your approval to run ${tool}${why} (policy rule ${statement.id}).`;
+}
+
+export function evaluatePolicyIr({ policy, toolName, toolParams, workspaceRoot }) {
   const normalized = normalizePolicyIr(policy);
-  const matches = normalized.statements.filter((statement) => statementMatches(statement, toolName, toolParams || {}));
+  const context = { workspaceRoot: typeof workspaceRoot === "string" ? workspaceRoot : "" };
+  const matches = normalized.statements.filter((statement) => statementMatches(statement, toolName, toolParams || {}, context));
   const forbid = matches.find((statement) => statement.effect === "forbid");
   if (forbid) {
     return { allowed: false, reason: `ArmorClaude policy forbid: ${forbid.id}`, matchedRule: forbid };
   }
   const approval = matches.find((statement) => statement.effect === "require_approval");
   if (approval) {
-    return { allowed: false, reason: `ArmorClaude policy requires approval: ${approval.id}`, matchedRule: approval };
+    return { allowed: false, reason: explainApproval(approval, toolName, toolParams), matchedRule: approval };
   }
   const permit = matches.find((statement) => statement.effect === "permit");
   if (permit) {
@@ -506,7 +582,7 @@ export function evaluatePolicyIr({ policy, toolName, toolParams }) {
   if (normalized.defaults.decision === "hold") {
     return {
       allowed: false,
-      reason: `ArmorClaude policy default hold: no statement matched tool ${toolName}. Active default is hold.`,
+      reason: `ArmorClaude needs your approval to run ${toolName || "this tool"} because no policy rule explicitly allows it and the default is to hold unmatched actions for review.`,
       matchedRule: {
         id: "default-hold",
         effect: "require_approval",

--- a/scripts/lib/policy.mjs
+++ b/scripts/lib/policy.mjs
@@ -159,9 +159,9 @@ export function detectDataClasses(toolName, toolParams) {
   return classes;
 }
 
-export function evaluatePolicy({ policy, toolName, toolParams }) {
+export function evaluatePolicy({ policy, toolName, toolParams, workspaceRoot }) {
   const normalizedPolicy = normalizePolicy(policy);
   const dataClasses = detectDataClasses(toolName, toolParams);
-  const decision = evaluatePolicyIr({ policy: normalizedPolicy, toolName, toolParams });
+  const decision = evaluatePolicyIr({ policy: normalizedPolicy, toolName, toolParams, workspaceRoot });
   return { ...decision, dataClasses: Array.from(dataClasses) };
 }

--- a/tests/policy-ir.test.mjs
+++ b/tests/policy-ir.test.mjs
@@ -180,7 +180,8 @@ test("evaluatePolicyIr maps default hold to approval for unmatched tools", () =>
   });
   const held = evaluatePolicyIr({ policy, toolName: "Write", toolParams: { file_path: "a.txt" } });
   assert.equal(held.allowed, false);
-  assert.match(held.reason, /default hold: no statement matched tool Write/);
+  assert.match(held.reason, /needs your approval to run Write/);
+  assert.match(held.reason, /hold unmatched actions for review/);
   assert.equal(held.matchedRule.effect, "require_approval");
   assert.equal(held.matchedRule.id, "default-hold");
 });

--- a/tests/policy.test.mjs
+++ b/tests/policy.test.mjs
@@ -180,7 +180,7 @@ test("handlePreToolUse asks with Claude Code native UI when policy requires appr
     config
   );
   assert.equal(output?.hookSpecificOutput?.permissionDecision, "ask");
-  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /requires approval: hold-bash/);
+  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /policy rule hold-bash/);
 });
 
 test("handlePreToolUse asks for held read-only tools instead of bypassing policy fast-path", async () => {
@@ -209,7 +209,7 @@ test("handlePreToolUse asks for held read-only tools instead of bypassing policy
     config
   );
   assert.equal(output?.hookSpecificOutput?.permissionDecision, "ask");
-  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /requires approval: hold-read/);
+  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /policy rule hold-read/);
 });
 
 test("handlePreToolUse asks through native UI for default hold unmatched tools", async () => {
@@ -244,7 +244,7 @@ test("handlePreToolUse asks through native UI for default hold unmatched tools",
     config
   );
   assert.equal(output?.hookSpecificOutput?.permissionDecision, "ask");
-  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /default hold/);
+  assert.match(output?.hookSpecificOutput?.permissionDecisionReason || "", /hold unmatched actions for review/);
 });
 
 test("handlePreToolUse lets Claude coordination tools bypass user policy default deny", async () => {

--- a/tests/within-workspace.test.mjs
+++ b/tests/within-workspace.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { evaluatePolicyIr, registerConditionDescriber } from "../scripts/lib/policy-ir.mjs";
+
+const WORKSPACE = path.resolve("/home/user/project");
+
+function workspacePolicy() {
+  return {
+    schemaVersion: "armor.policy.v1",
+    kind: "PolicyProfile",
+    metadata: { name: "architect", description: "write inside workspace" },
+    defaults: { decision: "hold", conflictResolution: "deny_overrides" },
+    statements: [
+      {
+        id: "approve-outside",
+        effect: "require_approval",
+        principal: { type: "agent", id: "claude-code" },
+        action: { type: "tool", in: ["Write", "Edit", "MultiEdit"] },
+        resource: { type: "file", scope: "current" },
+        conditions: [{ field: "file.path", op: "within_workspace", value: false }]
+      },
+      {
+        id: "permit-inside",
+        effect: "permit",
+        principal: { type: "agent", id: "claude-code" },
+        action: { type: "tool", in: ["Write", "Edit", "MultiEdit"] },
+        resource: { type: "file", scope: "current" },
+        conditions: [{ field: "file.path", op: "within_workspace", value: true }]
+      }
+    ]
+  };
+}
+
+test("within_workspace: an in-workspace edit is permitted", () => {
+  const decision = evaluatePolicyIr({
+    policy: workspacePolicy(),
+    toolName: "Edit",
+    toolParams: { file_path: path.join(WORKSPACE, "src/app.js") },
+    workspaceRoot: WORKSPACE
+  });
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.matchedRule.id, "permit-inside");
+});
+
+test("within_workspace: an out-of-workspace edit requires approval and explains why", () => {
+  const outside = path.resolve("/home/user/other-repo/lib.js");
+  const decision = evaluatePolicyIr({
+    policy: workspacePolicy(),
+    toolName: "Edit",
+    toolParams: { file_path: outside },
+    workspaceRoot: WORKSPACE
+  });
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.matchedRule.id, "approve-outside");
+  assert.match(decision.reason, /outside the workspace/);
+  assert.match(decision.reason, /approve-outside/);
+  assert.ok(decision.reason.includes(outside));
+});
+
+test("within_workspace: absolute in-workspace path is not mis-classified (regression)", () => {
+  // Before the fix, every absolute path was treated as "not within workspace",
+  // so an in-workspace edit never matched permit-inside.
+  const inside = path.join(WORKSPACE, "deep/nested/file.txt");
+  const decision = evaluatePolicyIr({
+    policy: workspacePolicy(),
+    toolName: "Write",
+    toolParams: { file_path: inside },
+    workspaceRoot: WORKSPACE
+  });
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.matchedRule.id, "permit-inside");
+});
+
+test("within_workspace: unknown workspace root fails safe to approval", () => {
+  const decision = evaluatePolicyIr({
+    policy: workspacePolicy(),
+    toolName: "Edit",
+    toolParams: { file_path: path.join(WORKSPACE, "src/app.js") },
+    workspaceRoot: "" // can't determine the root → treat as outside
+  });
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.matchedRule.id, "approve-outside");
+});
+
+test("approval messaging is modular via registerConditionDescriber", () => {
+  registerConditionDescriber("network.host", (condition, actual) => `custom host clause for ${actual}`);
+  const policy = {
+    schemaVersion: "armor.policy.v1",
+    kind: "PolicyProfile",
+    metadata: { name: "net", description: "" },
+    defaults: { decision: "deny", conflictResolution: "deny_overrides" },
+    statements: [
+      {
+        id: "approve-net",
+        effect: "require_approval",
+        principal: { type: "agent", id: "claude-code" },
+        action: { type: "tool", eq: "WebFetch" },
+        resource: { type: "network", scope: "current" },
+        conditions: [{ field: "network.host", op: "eq", value: "example.com" }]
+      }
+    ]
+  };
+  const decision = evaluatePolicyIr({
+    policy,
+    toolName: "WebFetch",
+    toolParams: { url: "https://example.com/x" }
+  });
+  assert.equal(decision.allowed, false);
+  assert.match(decision.reason, /custom host clause for example\.com/);
+});


### PR DESCRIPTION
within_workspace never compared the path to the workspace root: it returned true only for relative paths without "..", and ignored the condition's expected value. Claude Code tools always pass absolute paths, so every real Write/Edit was classed "not within workspace" — neither the approve-outside rule nor the permit-inside rule ever matched, silently disabling a policy's workspace scoping.

- policy-ir.mjs: resolve paths against the workspace root and honor value:true/false; thread workspaceRoot through evaluatePolicyIr. An unknown root fails safe to "outside" (require approval).
- policy.mjs / engine.mjs: pass the workspace root (CLAUDE_PROJECT_DIR or hook payload cwd, not process.cwd() — the daemon runs in the data dir) into the evaluator.
- Approval reasons now explain why approval is required, via a modular condition-describer registry (registerConditionDescriber) so new explanations are table entries, not edits to the approval flow.
- Add inside/outside/unknown-root + modular-messaging tests; update existing copy assertions.