### PR TITLE
fix: register /armor as a global bare slash command

### DIFF
--- a/commands/armor.md
+++ b/commands/armor.md
@@ -1,4 +1,6 @@
 ---
-description: Manage ArmorClaude policy through the secure hook
-argument-hint: "policy <list|add|stage|confirm|cancel|profile|mcp|settings> [args]"
+description: Manage ArmorClaude policy — list, add, confirm, profile, mcp, settings
+argument-hint: "yes | no | policy <list|add|confirm|cancel|template|remove|reset|view|export|rebind> | profile <list|switch|save|delete> | mcp <list|approve|deny> | settings enforcement <local|opa>"
 ---
+
+/armor $ARGUMENTS

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "build": "echo 'no build step'",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "node scripts/install.mjs"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Installs the global /armor slash command into ~/.claude/commands/armor.md
+ * so users can type /armor yes instead of /armorclaude:armor yes.
+ */
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLUGIN_CMD = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  ".claude",
+  "commands",
+  "armor.md"
+);
+
+const GLOBAL_CMD_DIR = path.join(os.homedir(), ".claude", "commands");
+const GLOBAL_CMD = path.join(GLOBAL_CMD_DIR, "armor.md");
+
+async function install() {
+  const src = await readFile(PLUGIN_CMD, "utf8");
+  await mkdir(GLOBAL_CMD_DIR, { recursive: true });
+
+  if (existsSync(GLOBAL_CMD)) {
+    const existing = await readFile(GLOBAL_CMD, "utf8");
+    if (existing === src) {
+      console.log("ArmorClaude: /armor global command already up to date.");
+      return;
+    }
+  }
+
+  await writeFile(GLOBAL_CMD, src, "utf8");
+  console.log(`ArmorClaude: installed /armor global command → ${GLOBAL_CMD}`);
+}
+
+install().catch((err) => {
+  // Non-fatal — don't break npm install if this fails.
+  console.warn(`ArmorClaude: could not install /armor command: ${err?.message ?? err}`);
+});


### PR DESCRIPTION
## Problem

Users had to type `/armorclaude:armor yes` because Claude Code namespaces MCP plugin commands with the server name. Typing `/armor yes` either errored or went unrecognized.

## Fix

- **`scripts/install.mjs`** — copies `commands/armor.md` into `~/.claude/commands/armor.md` on install. Claude Code treats files in `~/.claude/commands/` as global bare slash commands (no namespace prefix).
- **`package.json`** — `postinstall` runs the installer automatically on `npm install`.
- **`commands/armor.md`** — updated with full argument hint and a `/armor $ARGUMENTS` passthrough body so the `UserPromptSubmit` hook intercepts the command naturally.

## How it works

1. User types `/armor yes`
2. Claude Code recognizes `/armor` as a registered global command (from `~/.claude/commands/armor.md`)
3. The command body `/armor $ARGUMENTS` expands to `/armor yes` and submits as a message
4. The existing `UserPromptSubmit` hook intercepts it via `isArmorPolicyCommand`, processes it, and blocks the message from going to the AI

## Test plan

- [ ] `npm install` → logs `ArmorClaude: installed /armor global command → ~/.claude/commands/armor.md`
- [ ] Type `/armor` in Claude Code — tab-complete works, command is recognized
- [ ] Type `/armor yes` — armor confirmation runs (no "command not found")
- [ ] Type `/armor policy list` — lists current rules
- [ ] `/armorclaude:armor yes` still works (unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)