### PR TITLE
fix: policy template falls back to seeded profiles on disk

### DIFF
--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -17,6 +17,10 @@ import {
 const PENDING_FILE = "policy-pending.json";
 const DRAFTS_FILE = "policy-drafts.json";
 const PROPOSAL_TTL_MS = 30 * 60 * 1000;
+// Safe profile/template slug: lowercase alphanumeric, hyphen-separated.
+// Rejects path separators and "." so a template name can never traverse
+// outside the profiles directory (e.g. "../foo", "a/b").
+const SAFE_PROFILE_NAME = /^[a-z0-9][a-z0-9-]*$/;
 const KNOWN_CLAUDE_TOOLS = new Set([
   "*",
   "Agent",
@@ -2287,11 +2291,14 @@ export async function handleArmorPolicyCommand(prompt, config) {
 
     case "template": {
       let tmpl = getTemplate(parsed.name);
-      // Fall back to seeded profile on disk so new bundles work without a
-      // daemon version bump — profiles are seeded at startup from templates.
-      if (!tmpl) {
+      // Fall back to a seeded builtin profile on disk so new bundles work
+      // without a daemon version bump — profiles are seeded at startup from
+      // templates. Only builtins are eligible: user-created profiles must not
+      // be applicable via `policy template`, and the name must be a safe slug
+      // so we never resolve a path outside the profiles directory.
+      if (!tmpl && SAFE_PROFILE_NAME.test(parsed.name)) {
         const seeded = await loadProfile(config, parsed.name);
-        if (seeded?.policy) {
+        if (seeded?.policy && seeded.profile?.createdBy === "builtin") {
           tmpl = {
             name: seeded.profile?.name ?? parsed.name,
             description: seeded.profile?.description ?? "",
@@ -2300,7 +2307,10 @@ export async function handleArmorPolicyCommand(prompt, config) {
         }
       }
       if (!tmpl) {
-        const seededNames = (await listProfiles(config)).map((p) => p.name);
+        const seededNames = (await listProfiles(config))
+          .filter((p) => p.profile?.createdBy === "builtin")
+          .map((p) => p.profile?.name)
+          .filter(Boolean);
         const allNames = [...new Set([...getTemplateNames(), ...seededNames])];
         return `Unknown template: ${parsed.name}\nAvailable: ${allNames.join(", ")}`;
       }

--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -2286,9 +2286,23 @@ export async function handleArmorPolicyCommand(prompt, config) {
     }
 
     case "template": {
-      const tmpl = getTemplate(parsed.name);
+      let tmpl = getTemplate(parsed.name);
+      // Fall back to seeded profile on disk so new bundles work without a
+      // daemon version bump — profiles are seeded at startup from templates.
       if (!tmpl) {
-        return `Unknown template: ${parsed.name}\nAvailable: ${getTemplateNames().join(", ")}`;
+        const seeded = await loadProfile(config, parsed.name);
+        if (seeded?.policy) {
+          tmpl = {
+            name: seeded.profile?.name ?? parsed.name,
+            description: seeded.profile?.description ?? "",
+            policy: seeded.policy,
+          };
+        }
+      }
+      if (!tmpl) {
+        const seededNames = (await listProfiles(config)).map((p) => p.name);
+        const allNames = [...new Set([...getTemplateNames(), ...seededNames])];
+        return `Unknown template: ${parsed.name}\nAvailable: ${allNames.join(", ")}`;
       }
       const state = await loadPolicyState(config.policyFile);
       const proposedPolicy = normalizePolicyIr(tmpl.policy);

--- a/tests/armor-policy-commands.test.mjs
+++ b/tests/armor-policy-commands.test.mjs
@@ -11,6 +11,7 @@ import {
 } from "../scripts/lib/armor-policy-commands.mjs";
 import { handleUserPromptExpansion, handleUserPromptSubmit } from "../scripts/lib/engine.mjs";
 import { savePolicyState } from "../scripts/lib/policy.mjs";
+import { saveProfile } from "../scripts/lib/policy-profiles.mjs";
 
 function buildConfig(tmpDir) {
   return {
@@ -1233,6 +1234,65 @@ test("/armor policy template rejects unknown template", async () => {
   const config = buildConfig(tmp);
   const out = await handleArmorPolicyCommand("/armor policy template nonexistent", config);
   assert.ok(out.includes("Unknown template"));
+});
+
+// Helper: create a profile on disk with a real (normalized) policy, then set
+// its createdBy. This simulates either a builtin profile shipped in a newer
+// bundle that the daemon's in-memory POLICY_TEMPLATES does not yet know about,
+// or a user-created profile. We go through saveProfile so the policy IR is
+// valid, then patch createdBy on disk (saveProfile always writes "user").
+async function writeProfileFile(config, name, createdBy) {
+  await saveProfile(config, name, `${createdBy} profile ${name}`, [
+    { id: "allow-read", action: "allow", tool: "Read" },
+    { id: "hold-bash", action: "hold", tool: "Bash" },
+  ]);
+  const file = path.join(config.dataDir, "profiles", `${name}.json`);
+  const data = JSON.parse(await readFile(file, "utf8"));
+  data.profile.createdBy = createdBy;
+  await writeFile(file, JSON.stringify(data, null, 2));
+}
+
+test("/armor policy template applies a seeded builtin profile absent from POLICY_TEMPLATES", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armor-policy-test-"));
+  const config = buildConfig(tmp);
+  await seedPolicy(config);
+  // "future-builtin" is not a compiled-in template, but is present on disk as
+  // a builtin (as if seeded by a newer bundle).
+  await writeProfileFile(config, "future-builtin", "builtin");
+
+  const tmplOut = await handleArmorPolicyCommand("/armor policy template future-builtin", config);
+  assert.ok(tmplOut.includes("confirm"), `expected a proposal, got: ${tmplOut}`);
+  assert.ok(!tmplOut.includes("Unknown template"));
+
+  await handleArmorPolicyCommand("/armor policy confirm", config);
+  const listOut = await handleArmorPolicyCommand("/armor policy list", config);
+  assert.ok(listOut.includes("allow-read"));
+  assert.ok(listOut.includes("hold-bash"));
+});
+
+test("/armor policy template refuses a user-created profile", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armor-policy-test-"));
+  const config = buildConfig(tmp);
+  await seedPolicy(config);
+  // A user-created profile on disk must NOT be applicable as a template.
+  await writeProfileFile(config, "my-custom", "user");
+
+  const out = await handleArmorPolicyCommand("/armor policy template my-custom", config);
+  assert.ok(out.includes("Unknown template"), `expected rejection, got: ${out}`);
+  // A user profile must not be advertised in the "Available" template list
+  // (the requested name still appears in the "Unknown template: <name>" line).
+  const available = out.split("Available:")[1] ?? "";
+  assert.ok(!available.includes("my-custom"), `user profile leaked into Available: ${out}`);
+});
+
+test("/armor policy template rejects path-traversal names", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "armor-policy-test-"));
+  const config = buildConfig(tmp);
+  await seedPolicy(config);
+  for (const bad of ["../evil", "a/b", "..", "UPPER"]) {
+    const out = await handleArmorPolicyCommand(`/armor policy template ${bad}`, config);
+    assert.ok(out.includes("Unknown template"), `expected rejection for "${bad}", got: ${out}`);
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`/armorclaude:armor policy template architect` returned \"Unknown template: architect\" even after PR #75 seeded the profiles on disk, because the template lookup only checked the hardcoded `POLICY_TEMPLATES` map in code — never the seeded files.

## Fix

In the `case "template":` handler, when the name isn't in `POLICY_TEMPLATES`, fall back to reading the seeded profile from `~/.claude/armorclaude/profiles/<name>.json`. New bundles are available immediately after daemon startup seeds them — no version bump, no daemon restart, no cache sync required.

## Why this matters

Users on any installed version get new bundles as soon as the daemon restarts and re-seeds. The version number no longer needs to change just to add new policy bundles.

## Test plan

- [ ] On an older cached plugin version, run `/armorclaude:armor policy template architect` — should work
- [ ] Add a new bundle to `policy-templates.mjs`, restart daemon, apply via `policy template <new-name>` — works without version bump

🤖 Generated with [Claude Code](https://claude.ai/claude-code)