### PR TITLE
fix: use relative path for MCP bootstrap in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "armorclaude-policy": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs", "mcp"]
+      "args": ["scripts/bootstrap.mjs", "mcp"]
     }
   }
 }


### PR DESCRIPTION
## Problem

`.mcp.json` uses `\${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs` for the MCP server command args. `CLAUDE_PLUGIN_ROOT` is only set by Claude Code when the plugin is installed via the marketplace (`claude plugin install`).

When a developer clones this repo and points Claude Code at this `.mcp.json` directly, `CLAUDE_PLUGIN_ROOT` is unset, so the path expands to `/scripts/bootstrap.mjs` and the MCP server fails to start with:

```
Missing environment variables: CLAUDE_PLUGIN_ROOT
```

## Fix

Use a relative path (`scripts/bootstrap.mjs`) instead. Claude Code resolves `.mcp.json` command args relative to the project root, so this works for the cloned-repo/dev case.

This does not break the plugin-install case: `bootstrap.mjs` resolves all of its own paths via `import.meta.url` (see `const __dirname = path.dirname(fileURLToPath(import.meta.url))`), so it does not depend on `CLAUDE_PLUGIN_ROOT` and works regardless of how it is invoked.

## Testing

- `.mcp.json` remains valid JSON and passes `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)