### PR TITLE
fix: sync confirmed policy to backend for all engines

### DIFF
--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -1994,7 +1994,7 @@ function helpText() {
     "  /armorclaude:armor yes                           — apply current staged change",
     "  /armorclaude:armor no                            — discard current staged change",
     "  /armorclaude:armor policy export                 — dump policy as JSON",
-    "  /armorclaude:armor policy sync                   — push active policy to the dashboard",
+    "  /armorclaude:armor policy sync                   — push active policy to the dashboard (requires backend API key configured)",
     "",
     "  /armorclaude:armor mcp list                     — show detected MCPs",
     "  /armorclaude:armor mcp approve <server>         — approve an MCP server",
@@ -2369,15 +2369,13 @@ export async function handleArmorPolicyCommand(prompt, config) {
       }
       await clearPending(config);
 
-      // Push policy to backend for all engines (local is the default)
-      // whenever an API key is configured.
-      if (config.apiKey) {
-        try {
-          const { syncPolicy: syncToBackend } = await import("./backend-client.mjs");
-          await syncToBackend(config, nextState);
-        } catch {
-          // fire-and-forget — local policy is authoritative
-        }
+      // Push policy to backend for all engines (local is the default) when a
+      // backend is configured. Fire-and-forget: local policy is authoritative,
+      // and armor commands run under a long-lived daemon that outlives this
+      // call, so a detached promise flushes without blocking confirmation.
+      // Matches the hasBackend() check in backend-client.mjs.
+      if (config.apiKey && config.backendEndpoint) {
+        syncPolicyToBackend(config, nextState).catch(() => {});
       }
 
       return `Policy updated to v${nextState.version}. ${pending.reason}${profileNote}${cryptoNote}`;

--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -1994,6 +1994,7 @@ function helpText() {
     "  /armorclaude:armor yes                           — apply current staged change",
     "  /armorclaude:armor no                            — discard current staged change",
     "  /armorclaude:armor policy export                 — dump policy as JSON",
+    "  /armorclaude:armor policy sync                   — push active policy to the dashboard",
     "",
     "  /armorclaude:armor mcp list                     — show detected MCPs",
     "  /armorclaude:armor mcp approve <server>         — approve an MCP server",
@@ -2368,8 +2369,9 @@ export async function handleArmorPolicyCommand(prompt, config) {
       }
       await clearPending(config);
 
-      // OPA mode: push compiled bundle to backend
-      if (config.enforcementEngine === "opa" && config.apiKey) {
+      // Push policy to backend for all engines (local is the default)
+      // whenever an API key is configured.
+      if (config.apiKey) {
         try {
           const { syncPolicy: syncToBackend } = await import("./backend-client.mjs");
           await syncToBackend(config, nextState);


### PR DESCRIPTION
## Problem

Two related issues in `scripts/lib/armor-policy-commands.mjs`:

**(a) Policies never synced in the default `local` engine.** In the `confirm` handler, the backend push was gated on `config.enforcementEngine === "opa" && config.apiKey`. Since `local` is the default enforcement engine, plugin-authored policies were **never** synced to the dashboard in the common case — only OPA-mode deployments ever pushed anything. Dashboards therefore never saw policies authored via the plugin.

**(b) The `/armorclaude:armor policy sync` command was undocumented.** The command is implemented (`case "sync"`) but was never listed in the help text.

## Fix

**(a)** Remove the OPA gate. The condition is now `if (config.apiKey)`, so every confirmed policy syncs to the backend whenever an API key is configured, regardless of enforcement engine. The push remains fire-and-forget (wrapped in `try/catch`, non-blocking); local policy stays authoritative.

**(b)** Add a help-text line documenting `/armorclaude:armor policy sync`, matching the existing formatting/prefix style of the other policy commands.

The backend contract is unchanged: the plugin still posts to `POST /policies/sync` with `{version, policy, source, updatedAt}` via `syncPolicy` in `backend-client.mjs`. A matching backend endpoint is being added separately.

## Testing

- `npm run lint` (eslint) passes.
- `prettier --check` passes on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)