### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "description": "ArmorIQ intent-based security enforcement for Claude Code",


### PR DESCRIPTION
Bumps version to 0.2.5 to publish the following changes from merged PRs:

- #80: auto-sync confirmed policy to backend for all enforcement engines
- #78: policy template falls back to seeded builtin profiles on disk
- #79: .mcp.json uses relative path (fixes MCP for dev clones)
- #75: seed builtin profiles (architect/quality-guardian/velocity-machine/night-owl) on daemon startup
- #77: register /armor as bare global slash command
- #76: show /armorclaude:armor prefix in all user-facing prompts

After merge + npm publish, users on 0.2.5 will have every `policy confirm` auto-sync to the ArmorIQ backend automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)