### PR TITLE
fix(policy): sync terminal policy to backend as a staged proposal

### DIFF
--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -2495,7 +2495,7 @@ export async function handleArmorPolicyCommand(prompt, config) {
       const result = await pushProfileToBackend(config, profile);
       if (!result.ok)
         return `Failed to push profile "${parsed.name}": ${result.reason || `HTTP ${result.status}`}`;
-      return `Profile "${parsed.name}" pushed to organization.`;
+      return `Profile "${parsed.name}" staged as a proposal for your organization. Confirm it in the dashboard (Policies → Confirm) to activate.`;
     }
 
     case "profile-pull": {
@@ -2546,7 +2546,7 @@ export async function handleArmorPolicyCommand(prompt, config) {
       const state = await loadPolicyState(config.policyFile);
       const result = await syncPolicyToBackend(config, state);
       if (!result.ok) return `Sync failed: ${result.reason || `HTTP ${result.status}`}`;
-      return `Policy v${state.version} synced to backend.`;
+      return `Policy v${state.version} staged as a proposal on the backend. Confirm it in the dashboard (Policies → Confirm) to activate.`;
     }
 
     default:

--- a/scripts/lib/backend-client.mjs
+++ b/scripts/lib/backend-client.mjs
@@ -24,60 +24,88 @@ export async function autoRegisterMcp(config, serverName) {
   }
 }
 
-export async function pushProfile(config, profile) {
-  if (!hasBackend(config)) return { ok: false, reason: "no backend configured" };
+/** JSON fetch helper honoring the configured timeout + auth headers. */
+async function jsonRequest(config, method, apiPath, body) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs || 8000);
   try {
-    const res = await postJson(
-      endpoint(config, "/policies/profiles"),
-      profile,
-      buildAuthHeaders(config),
-      config.timeoutMs || 8000
-    );
-    return { ok: res.ok, status: res.status, data: res.data };
+    const res = await fetch(endpoint(config, apiPath), {
+      method,
+      headers: buildAuthHeaders(config),
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const data = await res.json().catch(() => null);
+    return { ok: res.ok, status: res.status, data };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Push the caller's policy to the backend as a STAGED PROPOSAL, using the armor
+ * profile lifecycle: PUT /policies/profiles/draft then POST
+ * /policies/profiles/propose. Both accept the plugin API key.
+ *
+ * Activation is intentionally NOT performed here — a human confirms the staged
+ * proposal from the dashboard (POST /policies/profiles/confirm is JWT-only).
+ * This is what makes a policy set from the terminal land in the DB and show up
+ * in the UI awaiting confirmation.
+ */
+export async function proposePolicy(config, policy, reason) {
+  if (!hasBackend(config)) return { ok: false, reason: "no backend configured" };
+  if (!policy) return { ok: false, reason: "no policy to propose" };
+  try {
+    const draft = await jsonRequest(config, "PUT", "/policies/profiles/draft", {
+      policy,
+      orgId: config.orgId || undefined,
+    });
+    if (!draft.ok) {
+      return { ok: false, status: draft.status, reason: `draft failed: HTTP ${draft.status}` };
+    }
+    const proposal = await jsonRequest(config, "POST", "/policies/profiles/propose", {
+      reason: reason || "Updated via /armor (terminal)",
+      orgId: config.orgId || undefined,
+    });
+    if (!proposal.ok) {
+      return {
+        ok: false,
+        status: proposal.status,
+        reason: `propose failed: HTTP ${proposal.status}`,
+      };
+    }
+    return { ok: true, status: proposal.status, data: proposal.data };
   } catch (err) {
     return { ok: false, reason: String(err?.message || err) };
   }
 }
 
+/** Push a saved profile's policy to the backend as a staged proposal. */
+export async function pushProfile(config, profile) {
+  return proposePolicy(
+    config,
+    profile?.policy,
+    `Profile "${profile?.profile?.name || "unnamed"}" proposed via /armor`
+  );
+}
+
+/** Sync the current active policy to the backend as a staged proposal. */
+export async function syncPolicy(config, policyState) {
+  return proposePolicy(config, policyState?.policy, "Policy synced via /armor (terminal)");
+}
+
+/** Read the org's active armor policy (API-key scoped: GET profiles/active). */
 export async function pullProfiles(config) {
   if (!hasBackend(config)) return { ok: false, reason: "no backend configured", profiles: [] };
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), config.timeoutMs || 8000);
-    const res = await fetch(endpoint(config, "/policies/profiles"), {
-      method: "GET",
-      headers: buildAuthHeaders(config),
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    const data = await res.json().catch(() => null);
-    return {
-      ok: res.ok,
-      status: res.status,
-      profiles: Array.isArray(data?.profiles) ? data.profiles : Array.isArray(data) ? data : [],
-    };
+    const res = await jsonRequest(config, "GET", "/policies/profiles/active");
+    const policy = res.data?.policy;
+    const profiles = policy
+      ? [{ profile: { name: "active", description: "Active org policy" }, policy }]
+      : [];
+    return { ok: res.ok, status: res.status, profiles };
   } catch (err) {
     return { ok: false, reason: String(err?.message || err), profiles: [] };
-  }
-}
-
-export async function syncPolicy(config, policyState) {
-  if (!hasBackend(config)) return { ok: false, reason: "no backend configured" };
-  try {
-    const res = await postJson(
-      endpoint(config, "/policies/sync"),
-      {
-        version: policyState.version,
-        policy: policyState.policy,
-        source: "armorclaude",
-        updatedAt: policyState.updatedAt,
-      },
-      buildAuthHeaders(config),
-      config.timeoutMs || 8000
-    );
-    return { ok: res.ok, status: res.status, data: res.data };
-  } catch (err) {
-    return { ok: false, reason: String(err?.message || err) };
   }
 }
 

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -76,15 +76,15 @@ export function loadConfig(env = process.env) {
 
   // ── The one userConfig field: api_key. UI primary, legacy env fallback. ──
   let apiKey = pluginOpt(env, "API_KEY", "ARMORIQ_API_KEY");
-  if (!apiKey) {
-    try {
-      const creds = JSON.parse(
-        readFileSync(path.join(homedir(), ".armoriq", "credentials.json"), "utf-8")
-      );
-      if (typeof creds?.apiKey === "string") apiKey = creds.apiKey;
-    } catch {
-      // no credentials file — local-only mode
-    }
+  let orgId = env.ARMORIQ_ORG_ID?.trim() || "";
+  try {
+    const creds = JSON.parse(
+      readFileSync(path.join(homedir(), ".armoriq", "credentials.json"), "utf-8")
+    );
+    if (!apiKey && typeof creds?.apiKey === "string") apiKey = creds.apiKey;
+    if (!orgId && typeof creds?.orgId === "string") orgId = creds.orgId;
+  } catch {
+    // no credentials file — local-only mode
   }
 
   return {
@@ -102,6 +102,7 @@ export function loadConfig(env = process.env) {
     // In local mock mode use a placeholder key so engine.mjs apiKey guards pass.
     // The mock server ignores auth headers so the value doesn't matter.
     apiKey: apiKey || (localMock ? "local-mock-key-00000000000000000000" : ""),
+    orgId,
     auditEnabled: Boolean(apiKey) || localMock,
 
     // Hardcoded — every behaviour toggle uses the value we've tested into

--- a/tests/backend-client.test.mjs
+++ b/tests/backend-client.test.mjs
@@ -135,17 +135,10 @@ test("autoRegisterMcp sends POST to /mcp/auto-register", async () => {
   }
 });
 
-test("pullProfiles parses backend response", async () => {
-  const mockProfiles = [
-    {
-      profile: { name: "org-lockdown", description: "Org lockdown" },
-      version: 1,
-      policy: { rules: [] },
-    },
-  ];
+test("pullProfiles reads the active org policy", async () => {
   const { server, url } = await startMockServer((req, res) => {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ profiles: mockProfiles }));
+    res.end(JSON.stringify({ version: 2, policy: { rules: [] } }));
   });
   try {
     const result = await pullProfiles({
@@ -155,26 +148,26 @@ test("pullProfiles parses backend response", async () => {
     });
     assert.equal(result.ok, true);
     assert.equal(result.profiles.length, 1);
-    assert.equal(result.profiles[0].profile.name, "org-lockdown");
+    assert.equal(result.profiles[0].profile.name, "active");
   } finally {
     server.close();
   }
 });
 
-test("syncPolicy sends policy state to /policies/sync", async () => {
-  let receivedBody = null;
+test("syncPolicy stages a draft then a proposal", async () => {
+  const hits = [];
   const { server, url } = await startMockServer((req, res) => {
     let body = "";
     req.on("data", (c) => (body += c));
     req.on("end", () => {
-      receivedBody = JSON.parse(body);
+      hits.push({ method: req.method, path: req.url, body: body ? JSON.parse(body) : null });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
     });
   });
   try {
     const result = await syncPolicy(
-      { apiKey: "test-key", backendEndpoint: url, timeoutMs: 5000 },
+      { apiKey: "test-key", backendEndpoint: url, timeoutMs: 5000, orgId: "org-1" },
       {
         version: 3,
         policy: { rules: [{ id: "p1", action: "deny", tool: "Bash" }] },
@@ -182,8 +175,14 @@ test("syncPolicy sends policy state to /policies/sync", async () => {
       }
     );
     assert.equal(result.ok, true);
-    assert.equal(receivedBody.version, 3);
-    assert.equal(receivedBody.source, "armorclaude");
+    assert.equal(hits.length, 2);
+    assert.equal(hits[0].method, "PUT");
+    assert.ok(hits[0].path.endsWith("/policies/profiles/draft"));
+    assert.deepEqual(hits[0].body.policy, {
+      rules: [{ id: "p1", action: "deny", tool: "Bash" }],
+    });
+    assert.equal(hits[1].method, "POST");
+    assert.ok(hits[1].path.endsWith("/policies/profiles/propose"));
   } finally {
     server.close();
   }
@@ -228,30 +227,28 @@ test("/armor policy profile push with apiKey sends to backend", async () => {
     await saveProfile(config, "my-profile", "test", [{ id: "p1", action: "allow", tool: "*" }]);
     const out = await handleArmorPolicyCommand("/armor policy profile push my-profile", config);
     assert.ok(received, "Backend should have received the request");
-    assert.ok(out.includes("pushed"));
+    assert.ok(out.includes("proposal"));
   } finally {
     server.close();
   }
 });
 
 test("/armor policy profile pull with apiKey saves profiles locally", async () => {
-  const mockProfiles = [
-    {
-      profile: { name: "from-org", description: "Org profile" },
-      version: 1,
-      policy: { rules: [{ id: "o1", action: "deny", tool: "Bash" }] },
-    },
-  ];
   const { server, url } = await startMockServer((req, res) => {
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ profiles: mockProfiles }));
+    res.end(
+      JSON.stringify({
+        version: 1,
+        policy: { rules: [{ id: "o1", action: "deny", tool: "Bash" }] },
+      })
+    );
   });
   try {
     const tmp = await mkdtemp(path.join(os.tmpdir(), "backend-test-"));
     const config = buildConfig(tmp, { apiKey: "test-key", backendEndpoint: url });
     const out = await handleArmorPolicyCommand("/armor policy profile pull", config);
     assert.ok(out.includes("Pulled 1"));
-    const local = await loadProfile(config, "from-org");
+    const local = await loadProfile(config, "active");
     assert.ok(local);
     assert.equal(local.policy.rules, undefined);
     assert.equal(local.rules, undefined);
@@ -274,7 +271,7 @@ test("/armor policy sync with apiKey sends to backend", async () => {
     await seedPolicy(config, [{ id: "p1", action: "deny", tool: "Bash" }]);
     const out = await handleArmorPolicyCommand("/armor policy sync", config);
     assert.ok(received);
-    assert.ok(out.includes("synced"));
+    assert.ok(out.includes("staged"));
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Problem
Policy set from the terminal via `/armor` never showed up in the dashboard. The plugin's `backend-client.mjs` called routes that **don't exist** on the current backend:

| Called | Reality |
|---|---|
| `POST /policies/profiles` (`pushProfile`) | no such route → 404 |
| `POST /policies/sync` (`syncPolicy`) | no such route → 404 |
| `GET /policies/profiles` w/ API key (`pullProfiles`) | JWT-only → 401 |

The sync on confirm is fire-and-forget (`.catch(() => {})`), so it failed silently and nothing reached the org DB.

## Fix
Rework `backend-client.mjs` to the **real armor profile lifecycle**, authenticated with the plugin API key (unblocked by conmap-auto **#462**):

- `proposePolicy()` → `PUT /policies/profiles/draft` then `POST /policies/profiles/propose`
- `pushProfile()` / `syncPolicy()` delegate to `proposePolicy()`
- `pullProfiles()` → `GET /policies/profiles/active` (API-key scoped)
- `config` now surfaces `orgId` (from `~/.armoriq/credentials.json` or `ARMORIQ_ORG_ID`) for scoping

## Security invariant preserved
The terminal only **stages a proposal**. Activation stays **human-only** — a user clicks **Confirm** in the dashboard (`POST /policies/profiles/confirm` is JWT-only). The API key cannot self-activate. This is exactly the "set from terminal → shows in UI → confirm in UI" flow.

## Tests
`tests/backend-client.test.mjs` updated to assert the draft→propose lifecycle, active-policy read, and new messages. `node --test tests/backend-client.test.mjs` → **14/14 pass**. eslint + prettier clean. (Pre-existing unrelated failures in `policy-profiles.test.mjs` exist on `main` and are untouched here.)

## Rollout note
Depends on conmap-auto #462 being deployed to prod (the draft/propose endpoints must accept the API key). Takes effect on users' machines once the plugin is rebuilt/reinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)