### PR TITLE
chore(release): bump plugin to 0.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "armorclaude",
       "source": "./",
       "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging. Production-hardcoded URLs (api.armoriq.ai + iap.armoriq.ai).",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
       "homepage": "https://armoriq.ai/tools/armorclaude",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "ArmorIQ intent-based security enforcement for Claude Code: policy-based tool access control, intent verification, CSRG cryptographic proofs, and audit logging.",
   "author": { "name": "ArmorIQ", "email": "license@armoriq.io" },
   "homepage": "https://armoriq.ai/tools/armorclaude",


### PR DESCRIPTION
Bumps `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` from **0.2.4 → 0.2.5**.

## Why
#89 (terminal→backend policy proposal fix) merged to `main`, but the Claude Code plugin updater gates on the version in these manifests — both still read `0.2.4`, so `/plugin → Update now` reports *"already at the latest version (0.2.4)"* and users never receive the fix. (`package.json` is already `0.2.5`; `private: true`, so there's no npm publish involved — distribution is git/marketplace via these version fields.)

## Effect
After merge, `/plugin → Update now` will see `0.2.5` and pull the fixed `backend-client.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)