### PR TITLE
feat(policy): multi-bundle template install with most-restrictive merge (0.2.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "armorclaude",
       "source": "./",
       "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging. Production-hardcoded URLs (api.armoriq.ai + iap.armoriq.ai).",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
       "homepage": "https://armoriq.ai/tools/armorclaude",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "ArmorIQ intent-based security enforcement for Claude Code: policy-based tool access control, intent verification, CSRG cryptographic proofs, and audit logging.",
   "author": { "name": "ArmorIQ", "email": "license@armoriq.io" },
   "homepage": "https://armoriq.ai/tools/armorclaude",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "description": "ArmorIQ intent-based security enforcement for Claude Code",

--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -5,6 +5,7 @@ import { readJson, writeJson } from "./fs-store.mjs";
 import { loadPolicyState, savePolicyState } from "./policy.mjs";
 import { canonicalPolicyHash, normalizePolicyIr, validatePolicyIr } from "./policy-ir.mjs";
 import { getTemplate, getTemplateNames } from "./policy-templates.mjs";
+import { mergePolicies } from "./policy-merge.mjs";
 import { listProfiles, loadProfile, saveProfile, deleteProfile } from "./policy-profiles.mjs";
 import { listMcpServers, setMcpServerStatus } from "./tool-registry.mjs";
 import { loadRuntimeState, saveRuntimeState } from "./runtime-state.mjs";
@@ -1849,8 +1850,16 @@ function parseCommand(prompt) {
   const removeMatch = rest.match(/^remove\s+(\S+)/i);
   if (removeMatch) return { cmd: "remove", id: removeMatch[1] };
 
-  const templateMatch = rest.match(/^template\s+(\S+)/i);
-  if (templateMatch) return { cmd: "template", name: templateMatch[1] };
+  // Accepts one or more bundle names (comma- or space-separated). Multiple
+  // bundles are merged (most-restrictive-wins) into a single policy.
+  const templateMatch = rest.match(/^template\s+(.+)/i);
+  if (templateMatch) {
+    const names = templateMatch[1]
+      .split(/[\s,]+/)
+      .map((n) => n.trim())
+      .filter(Boolean);
+    return { cmd: "template", names, name: names[0] };
+  }
 
   if (lower.startsWith("mcp ")) return parseMcpCommand(rest.slice(4).trim());
   if (lower.startsWith("profile ")) return parseProfileCommand(rest.slice(8).trim());
@@ -1992,7 +2001,7 @@ function helpText() {
     "  /armorclaude:armor policy rebind                 — reissue crypto binding for current policy",
     "  /armorclaude:armor policy remove <rule-id>       — propose removing a rule",
     "  /armorclaude:armor policy reset                  — propose clearing all rules",
-    "  /armorclaude:armor policy template <name>        — propose applying a template",
+    "  /armorclaude:armor policy template <name...>     — apply one template, or merge several (most-restrictive)",
     "  /armorclaude:armor policy confirm [proposal-id]  — apply staged change",
     "  /armorclaude:armor policy cancel [proposal-id]   — discard staged change",
     "  /armorclaude:armor yes                           — apply current staged change",
@@ -2291,41 +2300,72 @@ export async function handleArmorPolicyCommand(prompt, config) {
     }
 
     case "template": {
-      let tmpl = getTemplate(parsed.name);
-      // Fall back to a seeded builtin profile on disk so new bundles work
-      // without a daemon version bump — profiles are seeded at startup from
-      // templates. Only builtins are eligible: user-created profiles must not
-      // be applicable via `policy template`, and the name must be a safe slug
-      // so we never resolve a path outside the profiles directory.
-      if (!tmpl && SAFE_PROFILE_NAME.test(parsed.name)) {
-        const seeded = await loadProfile(config, parsed.name);
-        if (seeded?.policy && seeded.profile?.createdBy === "builtin") {
-          tmpl = {
-            name: seeded.profile?.name ?? parsed.name,
-            description: seeded.profile?.description ?? "",
-            policy: seeded.policy,
-          };
+      const names = parsed.names?.length ? parsed.names : [parsed.name].filter(Boolean);
+
+      // Resolve each requested bundle to a template. Falls back to a seeded
+      // builtin profile on disk so new bundles work without a daemon version
+      // bump. Only builtins are eligible, and the name must be a safe slug so we
+      // never resolve a path outside the profiles directory.
+      const resolve = async (nm) => {
+        let tmpl = getTemplate(nm);
+        if (!tmpl && SAFE_PROFILE_NAME.test(nm)) {
+          const seeded = await loadProfile(config, nm);
+          if (seeded?.policy && seeded.profile?.createdBy === "builtin") {
+            tmpl = {
+              name: seeded.profile?.name ?? nm,
+              description: seeded.profile?.description ?? "",
+              policy: seeded.policy,
+            };
+          }
         }
+        return tmpl;
+      };
+
+      const resolved = [];
+      const unknown = [];
+      for (const nm of names) {
+        const tmpl = await resolve(nm);
+        if (tmpl) resolved.push(tmpl);
+        else unknown.push(nm);
       }
-      if (!tmpl) {
+
+      if (unknown.length) {
         const seededNames = (await listProfiles(config))
           .filter((p) => p.profile?.createdBy === "builtin")
           .map((p) => p.profile?.name)
           .filter(Boolean);
         const allNames = [...new Set([...getTemplateNames(), ...seededNames])];
-        return `Unknown template: ${parsed.name}\nAvailable: ${allNames.join(", ")}`;
+        return `Unknown template${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}\nAvailable: ${allNames.join(", ")}`;
       }
+      if (!resolved.length) {
+        return `No template specified. Available: ${getTemplateNames().join(", ")}`;
+      }
+
       const state = await loadPolicyState(config.policyFile);
-      const proposedPolicy = normalizePolicyIr(tmpl.policy);
-      const pending = await stagePending(config, state, proposedPolicy, `template ${parsed.name}`, {
+      let proposedPolicy;
+      let summary;
+      let reason;
+      if (resolved.length === 1) {
+        proposedPolicy = normalizePolicyIr(resolved[0].policy);
+        summary = `Proposed: apply template "${resolved[0].name}" — ${resolved[0].description}`;
+        reason = `template ${resolved[0].name}`;
+      } else {
+        const picked = resolved.map((t) => t.name).join(", ");
+        proposedPolicy = mergePolicies(
+          resolved.map((t) => t.policy),
+          {
+            name: "custom-merged",
+            description: `Most-restrictive merge of: ${picked}`,
+          }
+        );
+        summary = `Proposed: merge ${resolved.length} bundles (most-restrictive) — ${picked}`;
+        reason = `template merge ${resolved.map((t) => t.name).join("+")}`;
+      }
+
+      const pending = await stagePending(config, state, proposedPolicy, reason, {
         type: "deterministic",
       });
-      return formatProposal(
-        pending,
-        state.policy,
-        proposedPolicy,
-        `Proposed: apply template "${tmpl.name}" — ${tmpl.description}`
-      );
+      return formatProposal(pending, state.policy, proposedPolicy, summary);
     }
 
     case "confirm": {

--- a/scripts/lib/policy-merge.mjs
+++ b/scripts/lib/policy-merge.mjs
@@ -1,0 +1,91 @@
+import { normalizePolicyIr, validatePolicyIr } from "./policy-ir.mjs";
+
+// Restrictiveness ranks. Merging always keeps the STRICTER choice so combining
+// bundles can never make the resulting policy more permissive than any input.
+const DEFAULT_RANK = { allow: 0, hold: 1, deny: 2 };
+const EFFECT_RANK = { permit: 0, require_approval: 1, forbid: 2 };
+
+/** Identity of a rule ignoring its effect: same principal+action+resource+conditions. */
+function ruleKey(statement) {
+  return JSON.stringify([
+    statement.principal,
+    statement.action,
+    statement.resource,
+    statement.conditions,
+  ]);
+}
+
+/**
+ * Merge multiple armor.policy.v1 bundles into a single conflict-free policy.
+ *
+ * Resolution (most-restrictive-wins, safe by construction):
+ *  - defaults.decision: strictest across inputs (deny > hold > allow).
+ *  - Two rules with the SAME target (principal+action+resource+conditions) but
+ *    different effects: keep the strictest effect (forbid > require_approval >
+ *    permit). Exact duplicates collapse to one.
+ *  - Rules that merely OVERLAP (not identical targets) are all kept; the engine's
+ *    deny_overrides conflict resolution settles them safely at evaluation time.
+ *  - Statement ids are made unique (collisions get a -N suffix).
+ *
+ * A single input is returned normalized (a no-op merge). Throws if the merged
+ * document fails IR validation.
+ */
+export function mergePolicies(policies, { name = "custom-merged", description } = {}) {
+  const list = Array.isArray(policies) ? policies : [policies];
+  if (list.length === 0) {
+    throw new Error("mergePolicies requires at least one policy");
+  }
+  const normalized = list.map((p) => normalizePolicyIr(p));
+
+  // Strictest default wins.
+  let decision = "allow";
+  for (const p of normalized) {
+    if ((DEFAULT_RANK[p.defaults.decision] ?? 0) > (DEFAULT_RANK[decision] ?? 0)) {
+      decision = p.defaults.decision;
+    }
+  }
+
+  // Collapse identical targets, keeping the strictest effect. Insertion order
+  // (first-seen) is preserved for deterministic output.
+  const byKey = new Map();
+  for (const p of normalized) {
+    for (const statement of p.statements) {
+      const key = ruleKey(statement);
+      const existing = byKey.get(key);
+      if (!existing || (EFFECT_RANK[statement.effect] ?? 0) > (EFFECT_RANK[existing.effect] ?? 0)) {
+        byKey.set(key, statement);
+      }
+    }
+  }
+
+  // Unique, stable ids.
+  const usedIds = new Set();
+  const statements = [];
+  for (const statement of byKey.values()) {
+    const base = statement.id || "stmt";
+    let id = base;
+    let n = 2;
+    while (usedIds.has(id)) id = `${base}-${n++}`;
+    usedIds.add(id);
+    statements.push({ ...statement, id });
+  }
+
+  const merged = {
+    schemaVersion: "armor.policy.v1",
+    kind: "PolicyProfile",
+    metadata: {
+      name,
+      description:
+        description ??
+        `Merged (most-restrictive) from: ${normalized.map((p) => p.metadata.name).join(", ")}`,
+    },
+    defaults: { decision, conflictResolution: "deny_overrides" },
+    statements,
+  };
+
+  const result = validatePolicyIr(merged);
+  if (!result.ok) {
+    throw new Error(`Merged policy is invalid: ${result.errors.join("; ")}`);
+  }
+  return result.policy;
+}

--- a/tests/policy-merge.test.mjs
+++ b/tests/policy-merge.test.mjs
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mergePolicies } from "../scripts/lib/policy-merge.mjs";
+
+function policy(name, decision, statements) {
+  return {
+    schemaVersion: "armor.policy.v1",
+    kind: "PolicyProfile",
+    metadata: { name, description: name },
+    defaults: { decision, conflictResolution: "deny_overrides" },
+    statements,
+  };
+}
+
+function stmt(id, effect, action, conditions = []) {
+  return {
+    id,
+    effect,
+    principal: { type: "agent", id: "claude-code" },
+    action,
+    resource: { type: "workspace", scope: "current" },
+    conditions,
+  };
+}
+
+test("strictest default wins (deny > hold > allow)", () => {
+  const merged = mergePolicies([
+    policy("a", "allow", []),
+    policy("b", "hold", []),
+    policy("c", "deny", []),
+  ]);
+  assert.equal(merged.defaults.decision, "deny");
+});
+
+test("hold beats allow when no deny present", () => {
+  const merged = mergePolicies([policy("a", "allow", []), policy("b", "hold", [])]);
+  assert.equal(merged.defaults.decision, "hold");
+});
+
+test("same target keeps the strictest effect (forbid > require_approval > permit)", () => {
+  const merged = mergePolicies([
+    policy("permit-bash", "allow", [stmt("s", "permit", { type: "tool", eq: "Bash" })]),
+    policy("forbid-bash", "deny", [stmt("s", "forbid", { type: "tool", eq: "Bash" })]),
+  ]);
+  const bashRules = merged.statements.filter(
+    (s) => s.action.eq === "Bash" || (s.action.in || []).includes("Bash")
+  );
+  assert.equal(bashRules.length, 1, "identical Bash target should collapse to one rule");
+  assert.equal(bashRules[0].effect, "forbid");
+});
+
+test("exact duplicate rules collapse to one", () => {
+  const a = stmt("read", "permit", { type: "tool", in: ["Read", "Grep"] });
+  const merged = mergePolicies([policy("a", "allow", [a]), policy("b", "allow", [a])]);
+  assert.equal(merged.statements.length, 1);
+});
+
+test("distinct (overlapping) rules are all kept with unique ids", () => {
+  const merged = mergePolicies([
+    policy("a", "hold", [
+      stmt("dup", "forbid", { type: "tool", eq: "Bash" }, [
+        { field: "bash.program", op: "in", value: ["rm"] },
+      ]),
+    ]),
+    policy("b", "hold", [
+      stmt("dup", "forbid", { type: "tool", eq: "Bash" }, [
+        { field: "bash.raw", op: "matches", value: "git push.*--force" },
+      ]),
+    ]),
+  ]);
+  assert.equal(merged.statements.length, 2, "different conditions => two distinct rules");
+  const ids = merged.statements.map((s) => s.id);
+  assert.equal(new Set(ids).size, 2, "ids must be unique");
+});
+
+test("result is a valid, normalized armor.policy.v1 document", () => {
+  const merged = mergePolicies(
+    [
+      policy("a", "allow", [stmt("r", "permit", { type: "tool", in: ["Read"] })]),
+      policy("b", "deny", [stmt("w", "require_approval", { type: "tool", in: ["Write"] })]),
+    ],
+    { name: "combo" }
+  );
+  assert.equal(merged.schemaVersion, "armor.policy.v1");
+  assert.equal(merged.defaults.conflictResolution, "deny_overrides");
+  assert.equal(merged.metadata.name, "combo");
+  assert.equal(merged.statements.length, 2);
+});
+
+test("single-policy merge is a normalized no-op", () => {
+  const merged = mergePolicies([
+    policy("solo", "hold", [stmt("r", "permit", { type: "tool", in: ["Read"] })]),
+  ]);
+  assert.equal(merged.defaults.decision, "hold");
+  assert.equal(merged.statements.length, 1);
+});


### PR DESCRIPTION
## What
`/armor policy template` now accepts **one or several** bundle names (comma- or space-separated):

```
/armor policy template architect
/armor policy template architect, night-owl, quality-guardian
```

A single name behaves exactly as before. Multiple names are **merged into one conflict-free policy**.

## Merge rules (most-restrictive-wins — safe by construction)
New module `scripts/lib/policy-merge.mjs`:
- `defaults.decision`: strictest across inputs — **deny > hold > allow**
- Same target (principal+action+resource+conditions), different effect: strictest kept — **forbid > require_approval > permit**
- Exact duplicate rules collapse; merely-overlapping rules are all kept and the engine's existing `deny_overrides` settles them at eval time
- Statement ids made unique; result re-validated against the armor.policy.v1 IR

Merging can **never** make the active policy more permissive than any selected bundle intended — the right default for a security tool. Conflicting `defaults` (architect=`hold`, night-owl=`deny`, velocity=`allow`) resolve deterministically to the strictest.

## Version
Bumps plugin to **0.2.6** (`plugin.json` + `marketplace.json` + `package.json`) so it's installable via `/plugin → Update now`.

## Tests
- `tests/policy-merge.test.mjs` — 7 cases (default precedence, effect precedence, dedupe, unique ids, validity, single no-op) → all pass
- Existing `/armor policy template` command tests still pass (5/5). Pre-existing unrelated failures in `armor-policy-commands.test.mjs` exist on `main` and are untouched.
- eslint + prettier + build (pre-commit) clean

## Note / follow-up
This is the **terminal** half. The dashboard multi-select picker (you asked for "both") is a separate follow-up across `conmap-auto` + `tools-frontend`. The 4 bundles as dashboard templates are in conmap-auto #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)