### PR TITLE
docs(installer): surface optional policy bundles in finale

### DIFF
--- a/install_armorclaude.sh
+++ b/install_armorclaude.sh
@@ -196,6 +196,20 @@ finale() {
 
 EOF
 
+  section "Policy bundles (optional)"
+  cat <<EOF
+
+  Bundles are opt-in — nothing is applied until you pick one and
+  confirm it. Apply one, or merge several (most-restrictive-wins):
+
+    ${D}> /armorclaude:armor template balanced${N}
+    ${D}> /armorclaude:armor template quality-guardian,architect${N}
+
+  Available: all-allow, strict-read-only, balanced, lockdown,
+             architect, quality-guardian, velocity-machine, night-owl
+
+EOF
+
   section "Manage anytime"
   cat <<EOF
 


### PR DESCRIPTION
## Summary
The installer never applies a policy bundle — applying one is opt-in *and* confirm-gated (the `template` command only stages a proposal the user must confirm). This PR just makes that choice visible at the end of install, so users know bundles exist and how to apply one, without changing any behavior.

## What changed
- Adds a **"Policy bundles (optional)"** section to `finale()` in `install_armorclaude.sh`:
  - States bundles are opt-in and nothing is applied until picked + confirmed.
  - Shows `/armorclaude:armor template <name>` (single) and merge (`a,b`, most-restrictive-wins) examples.
  - Lists the available bundles: all-allow, strict-read-only, balanced, lockdown, architect, quality-guardian, velocity-machine, night-owl.

## Deliberately NOT done
- No auto-apply / no "download bundle" step wired into the installer. That would bypass the propose→confirm safety (there's no CLI path to apply a bundle outside a session), so it's kept as informational only.

## Testing
- `bash -n install_armorclaude.sh` passes.
- lint / prettier / build hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)