### PR TITLE
fix(bootstrap): npm install fails on Windows (exit null) — run through shell

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "armorclaude",
       "source": "./",
       "description": "Intent-based security enforcement for Claude Code: declared plans, policy rules, intent-drift blocking, CSRG cryptographic proofs, and audit logging. Production-hardcoded URLs (api.armoriq.ai + iap.armoriq.ai).",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "category": "security",
       "tags": ["security", "policy", "audit", "intent", "armoriq", "mcp"],
       "homepage": "https://armoriq.ai/tools/armorclaude",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "armorclaude",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "ArmorIQ intent-based security enforcement for Claude Code: policy-based tool access control, intent verification, CSRG cryptographic proofs, and audit logging.",
   "author": { "name": "ArmorIQ", "email": "license@armoriq.io" },
   "homepage": "https://armoriq.ai/tools/armorclaude",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -32,16 +32,24 @@ function installedOk() {
 
 if (!installedOk()) {
   process.stderr.write("[armorclaude] installing dependencies (one-time)...\n");
+  // On Windows the npm launcher is npm.cmd, which Node cannot spawn without a
+  // shell — spawnSync("npm", …) fails with ENOENT and status null. Run through
+  // a shell there so the .cmd launcher resolves.
+  const isWindows = process.platform === "win32";
   const result = spawnSync(
     "npm",
     ["install", "--omit=dev", "--ignore-scripts", "--silent", "--no-audit", "--no-fund"],
     {
       cwd: pluginRoot,
       stdio: ["ignore", "ignore", "inherit"],
+      shell: isWindows,
     }
   );
   if (result.status !== 0) {
-    process.stderr.write("[armorclaude] npm install failed (exit " + result.status + ")\n");
+    const detail = result.error ? ": " + result.error.message : "";
+    process.stderr.write(
+      "[armorclaude] npm install failed (exit " + result.status + ")" + detail + "\n"
+    );
     process.exit(1);
   }
   try {


### PR DESCRIPTION
## Problem
On Windows, the plugin is unusable: every hook/MCP call loops on
`[armorclaude] installing dependencies (one-time)...` → `npm install failed (exit null)`, and the `armoriq` CLI never installs.

**Root cause:** `scripts/bootstrap.mjs` lazily installs deps with `spawnSync("npm", …)`. On Windows the npm launcher is `npm.cmd`, which Node cannot spawn without a shell — the spawn fails with `ENOENT`, so `result.status` is `null` ("exit null"). The one-time install never completes, `installedOk()` stays false, and the bootstrap re-fails on every load. macOS/Linux are unaffected.

## Fix
- Pass `shell: true` on `win32` so the `npm.cmd` launcher resolves.
- Surface `result.error.message` in the failure log (previously just "exit null", which hid the ENOENT).
- Bump `0.2.6 → 0.2.7` in `plugin.json` + `marketplace.json`. The install marker is version-keyed, so the bump forces a clean reinstall with the fixed bootstrap and lets existing installs pull the fix via `claude plugin update`.

## Testing
- `node --check scripts/bootstrap.mjs` passes; eslint + prettier + build hooks pass.
- Unblock verified conceptually on Windows: with `shell:true`, `npm.cmd` resolves and the install completes.

## Manual unblock for anyone already stuck (pre-update)
```powershell
cd $env:USERPROFILE\.claude\plugins\marketplaces\armoriq
npm install --omit=dev
node -e "const fs=require('fs');const p=require('./package.json');fs.writeFileSync('node_modules/.armorclaude-installed',p.version)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)