### PR TITLE
feat: optional default_template in /plugin configure (staged for confirm on first run)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,6 +13,11 @@
       "title": "ArmorIQ API Key",
       "description": "Your ArmorIQ API key (get one at https://armoriq.ai). Leave blank to run in local-only mode without backend audit/intent.",
       "sensitive": true
+    },
+    "default_template": {
+      "type": "string",
+      "title": "Default policy template",
+      "description": "Optional. One of: all-allow, strict-read-only, balanced, lockdown, architect, quality-guardian, velocity-machine, night-owl. On first run it is proposed (staged for your confirmation — never applied automatically). Leave blank to be shown the template picker instead."
     }
   }
 }

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -74,8 +74,10 @@ export function loadConfig(env = process.env) {
         : "https://iap-staging.armoriq.ai";
   const useProduction = activeEnv === "production";
 
-  // ── The one userConfig field: api_key. UI primary, legacy env fallback. ──
+  // ── userConfig fields. UI primary, legacy env fallback. ──
   let apiKey = pluginOpt(env, "API_KEY", "ARMORIQ_API_KEY");
+  // Optional default policy template applied (staged for confirm) on first run.
+  const defaultTemplate = pluginOpt(env, "DEFAULT_TEMPLATE");
   let orgId = env.ARMORIQ_ORG_ID?.trim() || "";
   try {
     const creds = JSON.parse(
@@ -104,6 +106,7 @@ export function loadConfig(env = process.env) {
     apiKey: apiKey || (localMock ? "local-mock-key-00000000000000000000" : ""),
     orgId,
     auditEnabled: Boolean(apiKey) || localMock,
+    defaultTemplate,
 
     // Hardcoded — every behaviour toggle uses the value we've tested into
     // the right default. To change one, edit this file.

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -14,7 +14,7 @@ import {
   denyPreToolWithHint,
 } from "./hook-output.mjs";
 import { isArmorPolicyCommand, handleArmorPolicyCommand } from "./armor-policy-commands.mjs";
-import { getTemplateNames } from "./policy-templates.mjs";
+import { getTemplateNames, getTemplate } from "./policy-templates.mjs";
 import {
   checkIntentTokenPlan,
   checkToolAgainstPlan,
@@ -372,14 +372,30 @@ export async function handleSessionStart(input, config) {
       () => false
     );
     if (!flagExists) {
-      const templates = getTemplateNames();
-      onboardingMsg =
-        "\n\nWelcome to ArmorClaude! No policy is configured yet.\n" +
-        "Choose a template to get started:\n\n" +
-        templates.map((t) => `  /armorclaude:armor policy template ${t}`).join("\n") +
-        "\n\nOr add individual rules:\n" +
-        "  /armorclaude:armor policy add allow Read and Grep, deny Write, hold Bash\n\n" +
-        "Type /armorclaude:armor for all commands.";
+      const pick = config.defaultTemplate;
+      if (pick && getTemplate(pick)) {
+        // Configured default template: stage it as a proposal (never silently
+        // applied) via the same command path the user would run by hand. The
+        // returned text is the standard proposal, awaiting explicit confirm.
+        const proposal = await handleArmorPolicyCommand(`/armor template ${pick}`, config);
+        onboardingMsg =
+          `\n\nWelcome to ArmorClaude! Your configured default template "${pick}" ` +
+          `has been proposed (nothing is active until you confirm):\n\n${proposal}`;
+      } else {
+        const templates = getTemplateNames();
+        const invalidNote =
+          pick && !getTemplate(pick)
+            ? `\nConfigured default template "${pick}" is not recognized — pick one below.\n`
+            : "";
+        onboardingMsg =
+          "\n\nWelcome to ArmorClaude! No policy is configured yet.\n" +
+          invalidNote +
+          "Choose a template to get started:\n\n" +
+          templates.map((t) => `  /armorclaude:armor policy template ${t}`).join("\n") +
+          "\n\nOr add individual rules:\n" +
+          "  /armorclaude:armor policy add allow Read and Grep, deny Write, hold Bash\n\n" +
+          "Type /armorclaude:armor for all commands.";
+      }
       await mkdir(config.dataDir, { recursive: true });
       await writeFile(onboardingFlag, new Date().toISOString(), "utf8");
     }


### PR DESCRIPTION
## What
Adds a second `userConfig` field — **`default_template`** — so a user can choose a starter policy right in `/plugin configure`, next to the API key. On first run the chosen template is **proposed (staged for confirmation)**, never silently applied.

## Why not a dropdown
Claude Code's plugin `userConfig` only supports `string | number | boolean | directory | file` — there is **no enum/select type**, so a constrained picker can't be rendered. The field is free-text and the eight valid names live in its `description`.

## Behavior (first run, no policy.json)
- **Valid name** (e.g. `balanced`) → staged via the existing `/armor template <name>` path → user confirms. Nothing is enforced or loosened without one explicit confirm.
- **Invalid name** → falls back to the template picker with a "not recognized" note.
- **Blank** → existing picker behavior, unchanged.

Deliberately **not** silent-apply: `all-allow` is one of the eight, and silently applying it would turn enforcement off unnoticed — so everything routes through stage→confirm.

## Changes
- `plugin.json` — add `default_template` userConfig field (names listed in description).
- `config.mjs` — read `CLAUDE_PLUGIN_OPTION_DEFAULT_TEMPLATE` → `config.defaultTemplate`.
- `engine.mjs` — first-run onboarding stages a valid configured template (reuses `handleArmorPolicyCommand`), else picker.

## Testing
- Manual harness across valid / invalid / blank: valid stages `policy-pending.json` and applies **no** `policy.json`; invalid + blank show the picker. ✅
- `node --check` on both modules; eslint + prettier + build hooks pass.
- Test suite: 13 pre-existing failures on `origin/main` (dev-targeted tests on production-hardcoded main); **this change adds zero new failures** (13 → 13, empty diff).

## Version note
Intentionally kept at **0.2.7** (no bump) per request. Consequence: existing 0.2.7 installs won't receive this via `claude plugin update` (same "already at latest" behavior seen earlier) — they need a remove + reinstall to pick it up. New installs get it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)