### PR TITLE
fix(sync): pull confirmed dashboard policy on session start (dashboard = source of truth)

### DIFF
--- a/scripts/lib/armor-policy-commands.mjs
+++ b/scripts/lib/armor-policy-commands.mjs
@@ -2594,6 +2594,75 @@ export async function handleArmorPolicyCommand(prompt, config) {
   }
 }
 
+/**
+ * Dashboard-authoritative sync: pull the org's CONFIRMED active policy from the
+ * backend and make it the local enforced policy. Called on session start.
+ *
+ * Fail-safe by construction: on ANY problem (no api key, network error, invalid
+ * remote policy, or crypto policy-token issuance failure) the local policy is
+ * left untouched — a failed pull never wipes or loosens enforcement. No-op when
+ * the remote policy already matches the local one.
+ *
+ * Returns { ok, changed, version?, reason? }.
+ */
+export async function syncActivePolicyFromBackend(config) {
+  if (!config.apiKey) return { ok: false, changed: false, reason: "no api key" };
+
+  const result = await pullProfilesFromBackend(config);
+  if (!result.ok)
+    return { ok: false, changed: false, reason: result.reason || `HTTP ${result.status}` };
+
+  const active = result.profiles.find((p) => p?.policy);
+  if (!active?.policy) return { ok: false, changed: false, reason: "no active org policy" };
+
+  const validated = validatePolicyIr(normalizePolicyIr(active.policy));
+  if (!validated.ok)
+    return {
+      ok: false,
+      changed: false,
+      reason: `invalid remote policy: ${validated.errors.join("; ")}`,
+    };
+  const remotePolicy = validated.policy;
+
+  const state = await loadPolicyState(config.policyFile);
+  if (canonicalPolicyHash(state.policy) === canonicalPolicyHash(remotePolicy)) {
+    return { ok: true, changed: false };
+  }
+
+  const now = new Date().toISOString();
+  const nextState = {
+    version: state.version + 1,
+    updatedAt: now,
+    updatedBy: "dashboard-sync",
+    policy: remotePolicy,
+    history: [
+      ...state.history,
+      {
+        version: state.version + 1,
+        updatedAt: now,
+        updatedBy: "dashboard-sync",
+        reason: "pulled confirmed org policy from dashboard",
+        policy: remotePolicy,
+      },
+    ],
+  };
+
+  // Re-issue the crypto policy token for the new policy, exactly like confirm.
+  // If issuance fails, do NOT overwrite local policy — keep enforcing the
+  // current one rather than switch to a policy we can't back with a token.
+  const cryptoResult = await issueCryptoPolicyTokenForState(config, nextState);
+  if (!cryptoResult.ok) {
+    return {
+      ok: false,
+      changed: false,
+      reason: `crypto token issuance failed: ${cryptoResult.error}`,
+    };
+  }
+
+  await savePolicyState(config.policyFile, nextState);
+  return { ok: true, changed: true, version: nextState.version };
+}
+
 async function stagePending(
   config,
   state,

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -13,7 +13,11 @@ import {
   denyPreTool,
   denyPreToolWithHint,
 } from "./hook-output.mjs";
-import { isArmorPolicyCommand, handleArmorPolicyCommand } from "./armor-policy-commands.mjs";
+import {
+  isArmorPolicyCommand,
+  handleArmorPolicyCommand,
+  syncActivePolicyFromBackend,
+} from "./armor-policy-commands.mjs";
 import { getTemplateNames, getTemplate } from "./policy-templates.mjs";
 import {
   checkIntentTokenPlan,
@@ -354,6 +358,25 @@ export async function handleSessionStart(input, config) {
       .catch(() => {});
   }
 
+  // --- Dashboard-authoritative sync: pull the confirmed org policy and make it
+  // the locally enforced policy, so the session enforces exactly what the
+  // dashboard shows. Awaited so it applies before any tool runs. Fail-safe:
+  // never throws and never wipes local policy on error (see the helper).
+  let syncNote = "";
+  if (config.apiKey) {
+    try {
+      const pulled = await syncActivePolicyFromBackend(config);
+      if (pulled.ok && pulled.changed) {
+        syncNote = ` Policy synced from dashboard (v${pulled.version}).`;
+        debugLog(config, `policy synced from backend: v${pulled.version}`);
+      } else if (!pulled.ok) {
+        debugLog(config, `policy sync skipped: ${pulled.reason}`);
+      }
+    } catch (err) {
+      debugLog(config, `policy sync error: ${err?.message || err}`);
+    }
+  }
+
   debugLog(config, `session started: ${sessionId}, mode=${config.mode}`);
 
   const modeLabel = config.mode === "enforce" ? "ENFORCING" : "MONITORING";
@@ -402,7 +425,7 @@ export async function handleSessionStart(input, config) {
   }
 
   return addPromptContext(
-    `ArmorClaude active (${modeLabel}, intent=${intentLabel})${onboardingMsg}`,
+    `ArmorClaude active (${modeLabel}, intent=${intentLabel})${syncNote}${onboardingMsg}`,
     "SessionStart"
   );
 }


### PR DESCRIPTION
## Problem
The dashboard says *"Confirmed policy is pulled by ArmorClaude on the next session"* — but nothing pulled it:
- Enforcement always reads **local `policy.json`** (`loadPolicyState` everywhere in `engine.mjs`).
- **`/armor policy sync`** only **pushes** — it stages the *local* policy as a backend proposal to confirm in the dashboard.
- **`/armor profile pull`** saved org profiles to disk but never applied them to the active policy.

Net effect users hit: dashboard edits never reach the terminal, terminal edits never reach the dashboard, and `policy sync` "does nothing" to the active policy. Nothing was hardcoded — there was simply no dashboard→terminal path.

## Fix (dashboard-authoritative, chosen behavior)
Add `syncActivePolicyFromBackend(config)` and call it on **session start** (when an API key is set):
1. `GET /policies/profiles/active` (the confirmed org policy)
2. validate the IR
3. re-issue the crypto policy token (same as `confirm`)
4. write it as the local enforced `policy.json` (version bump, `updatedBy: dashboard-sync`)

The session then enforces exactly what the dashboard shows.

### Fail-safe by construction
On **any** problem — no api key, network error, invalid remote policy, or crypto-token issuance failure — the local policy is left **untouched**. A failed pull never wipes or loosens enforcement. No-op when the remote policy already equals local (hash compare), so no version churn.

## Testing
End-to-end against a mock backend (serving `profiles/active` + the crypto `/intent` endpoint):
- first pull → applies the policy (`deny` default, version 1, `updatedBy: dashboard-sync`) ✅
- pull again unchanged → no-op (`changed:false`) ✅
- backend returns no policy → **fail-safe, version unchanged** ✅

Also exercised against the **live production backend** (local `~/.armoriq/credentials.json`): pulled and applied the real org active policy, crypto token issued. ✅

- `node --check` on both modules; eslint + prettier + build pass.
- Test suite: 13 pre-existing failures on `origin/main` (dev-targeted tests on production-hardcoded main); **zero new failures** (13 → 13).

## Version note
No version bump (stays 0.2.7) per prior preference. Consequence: existing 0.2.7 installs won't get this via `claude plugin update` — they need remove + reinstall. Happy to bump to 0.2.8 if you'd rather it reach installs via update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)