### PR TITLE
feat(tokens): report per-session token usage to the dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "armorclaude",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "armorclaude",
-      "version": "0.2.4",
+      "version": "0.2.6",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@armoriq/sdk": "^0.3.7",
+        "@armoriq/sdk": "^0.4.3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^3.25.76"
       },
@@ -24,9 +25,9 @@
       }
     },
     "node_modules/@armoriq/sdk": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.3.7.tgz",
-      "integrity": "sha512-CVNqsZ47FyXSB98/tjzo/LmUjisPQpJiid/kbwLK4KrTYLlAx/XBEOC4sFsLbAYXXubSLuYaUJi8njxNld4WKA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.4.3.tgz",
+      "integrity": "sha512-OP5gg1EP5I0zjodajzwEGCyQL6ktTino1xgZ7sFpAMq09QQxRxmVTM9arrfyMGOfyXf6/HmIkWK1HkCrS1wE6w==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
-    "@armoriq/sdk": "^0.3.7",
+    "@armoriq/sdk": "^0.4.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   },

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -102,8 +102,10 @@ export function loadConfig(env = process.env) {
 
     // userConfig-driven (the only one)
     // In local mock mode use a placeholder key so engine.mjs apiKey guards pass.
-    // The mock server ignores auth headers so the value doesn't matter.
-    apiKey: apiKey || (localMock ? "local-mock-key-00000000000000000000" : ""),
+    // The mock server ignores auth headers so the value doesn't matter, but it
+    // MUST match the @armoriq/sdk (>=0.4) key-format check (ak_test_/ak_live_/
+    // ak_claw_) or the SDK client constructor throws.
+    apiKey: apiKey || (localMock ? "ak_test_localmock000000000000" : ""),
     orgId,
     auditEnabled: Boolean(apiKey) || localMock,
     defaultTemplate,
@@ -137,6 +139,9 @@ export function loadConfig(env = process.env) {
     opaCircuitResetMs: 10000,
 
     // Identity — backend derives real identity from API key.
+    // productSlug is sent explicitly on dashboard telemetry (token usage) so
+    // per-product attribution works even if the API key has product=NULL.
+    productSlug: "armorclaude",
     llmId: "claude-code",
     mcpName: "claude-code",
     userId: "claude-user",

--- a/scripts/lib/engine.mjs
+++ b/scripts/lib/engine.mjs
@@ -33,6 +33,7 @@ import {
   validateCsrgProofHeaders,
 } from "./intent.mjs";
 import { createIapService, reanchorViaSdk, revokeViaSdk } from "./iap-service.mjs";
+import armoriqSdk from "@armoriq/sdk";
 import { computePolicyHash, evaluatePolicy, loadPolicyState } from "./policy.mjs";
 import { INTENT_PLAN_FORMAT, INTENT_PLAN_ZOD, normalizeIntentPlan } from "./intent-schema.mjs";
 import { extractPlanJsonBlock, parsePlanFile, resolvePlanFilePath } from "./planner.mjs";
@@ -309,6 +310,45 @@ async function emitAudit({ dto, config, iapService }) {
   }
   await iapService.createAuditLog(dto);
   return "sent (http)";
+}
+
+/**
+ * Best-effort: capture per-model token usage from the session transcript and
+ * report it to the dashboard via the SDK (`POST /dashboard/token-usage`). This
+ * is the single cross-tool path shared with ArmorCodex/Copilot:
+ * `summarizeTranscriptUsage` + `client.recordTokenUsage`.
+ *
+ * Stop fires every turn, so we debounce on the cumulative token total and only
+ * POST when it changed. The backend upsert SETS the per-(session,model) counts,
+ * so re-posting a cumulative total is idempotent and never double-counts.
+ * `product` is sent explicitly so attribution works even if the API key has
+ * product=NULL. `session.lastTokenTotal` is mutated in place; the caller
+ * persists it. Failures are swallowed — token telemetry never breaks the hook.
+ */
+async function reportTokenUsage(input, config, session, sessionId) {
+  if (!config.apiKey) return;
+  try {
+    const entries = armoriqSdk.summarizeTranscriptUsage(input?.transcript_path);
+    const total = entries.reduce(
+      (s, e) => s + e.inputTokens + e.outputTokens + e.cacheReadTokens + e.cacheWriteTokens,
+      0
+    );
+    if (total > 0 && total !== session.lastTokenTotal) {
+      const result = await getSdkClient(config).recordTokenUsage({
+        product: config.productSlug,
+        sessionId,
+        entries,
+      });
+      if (result?.ok) session.lastTokenTotal = total;
+      debugLog(
+        config,
+        `[tokens] ${entries.length} model(s) total=${total} ${result?.ok ? "ok" : "failed:" + (result?.reason || "")}`
+      );
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    debugLog(config, `[tokens] usage report failed (non-fatal): ${msg}`);
+  }
 }
 
 /**
@@ -1332,8 +1372,13 @@ export async function handleStop(input, config) {
     }
   }
 
+  // Report cumulative token usage from the transcript at the turn boundary.
+  // Mutates session.lastTokenTotal in place (debounce marker) which we persist.
+  await reportTokenUsage(input, config, session, sessionId);
+
   upsertSession(runtimeState, sessionId, {
     lastStopAt: nowEpochSeconds(),
+    lastTokenTotal: session.lastTokenTotal,
   });
   await saveRuntimeState(config.runtimeFile, runtimeState);
   return null;


### PR DESCRIPTION
## What
Reports per-session LLM token usage from ArmorClaude to the ArmorIQ dashboard so the **Token Usage** page (tools.armoriq) is populated.

## How
- On each `Stop` hook, parse the Claude Code transcript with the SDK's `summarizeTranscriptUsage`, sum cumulative per-model tokens, and POST via `client.recordTokenUsage` → `POST /dashboard/token-usage`.
- Debounced on the running total; the backend upsert **SETS** counts by `(org, product, session, model)`, so re-posting cumulative totals is idempotent (no double-counting).
- Sends `product="armorclaude"` explicitly, so a single product-agnostic API key works.

## Notes
- Bumps `@armoriq/sdk` → `^0.4.3` (the token methods only exist in 0.4.x). API-compatible superset for all methods the plugin already uses.
- 0.4.x now validates API-key format at client construction; fixed the local-mock placeholder key to the `ak_test_` format.

## Tests
`npm test`: 273 pass / 12 fail — the 12 fail identically on pristine `main` + old SDK (pre-existing, unrelated: policy help text, endpoints, onboarding, profiles). No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)