### PR TITLE
chore(deps): bump @armoriq/sdk to ^0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@armoriq/sdk": "^0.4.3",
+        "@armoriq/sdk": "^0.6.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^3.25.76"
       },
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@armoriq/sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.4.3.tgz",
-      "integrity": "sha512-OP5gg1EP5I0zjodajzwEGCyQL6ktTino1xgZ7sFpAMq09QQxRxmVTM9arrfyMGOfyXf6/HmIkWK1HkCrS1wE6w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@armoriq/sdk/-/sdk-0.6.2.tgz",
+      "integrity": "sha512-pWAosJcUsDmQ4SmPh4oejzqfAxyWDtBe9x73t57JiEq3Ty5Ml5Vt12vH+ywRILjObxq1gmlhsYfTIRxdA1XJ2g==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
-    "@armoriq/sdk": "^0.4.3",
+    "@armoriq/sdk": "^0.6.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^3.25.76"
   },


### PR DESCRIPTION
Bumps `@armoriq/sdk` `^0.4.3` → `^0.6.2` (latest).

API-compatible — verified all methods the plugin uses are present in 0.6.2: `capturePlan`, `getIntentToken`, `reanchor`, `revoke`, `delegateSubtree`, `verifyToken`, plus `summarizeTranscriptUsage` / `client.recordTokenUsage` (token reporting). Same client constructor + `ak_` key-format validation.

Tests unchanged: 273 pass / 12 pre-existing failures (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)